### PR TITLE
Feat: Implement claim_tokens function for full asset redemption with event emission

### DIFF
--- a/contracts/L1/src/ZeroXBridgeL1.sol
+++ b/contracts/L1/src/ZeroXBridgeL1.sol
@@ -180,6 +180,23 @@ contract ZeroXBridgeL1 is Ownable {
         emit FundsClaimed(msg.sender, amount);
     }
 
+
+    /**
+     * @dev Allows users to claim their full unlocked tokens
+     * @notice Users can only claim the full amount, partial claims are not allowed
+     */
+    function claim_tokens() external {
+        uint256 amount = claimableFunds[msg.sender];
+        require(amount > 0, "ZeroXBridge: No tokens to claim");
+        
+        // Reset claimable amount before transfer to prevent reentrancy
+        claimableFunds[msg.sender] = 0;
+
+        // Transfer full amount to user
+        claimableToken.safeTransfer(msg.sender, amount);
+        emit ClaimEvent(msg.sender, amount);
+    }
+
     // Function to update the GPS verifier address if needed
     function updateGpsVerifier(address _newVerifier) external onlyOwner {
         require(_newVerifier != address(0), "ZeroXBridge: Invalid address");


### PR DESCRIPTION
**Description**  
This pull request introduces the `claim_tokens()` function in the ZeroXBridge L1 contract, allowing users to redeem tokens after a successful burn event processed from L2. Users can only claim the full amount associated with their USD-equivalent deposited assets; partial claims are not allowed.

**Changes**  
- Added `claim_tokens()` to handle the claiming of unlocked tokens.
- Ensured that only full claims are allowed, with appropriate checks in place.
- Emitted `ClaimEvent` to notify successful claims.

**Test Coverage**  
- Verified the successful claiming of tokens by asserting the updated balance of the user.
- Confirmed that an error is thrown when attempting to claim with no funds.
- Checked that partial claims are not allowed, ensuring the full amount remains claimable.

**References**  
Closes Implement claim_tokens Function for L1 Unlock Requests #3