### PR TITLE
feat: allow approved contracts to mint xZBERC20

### DIFF
--- a/contracts/L2/Scarb.lock
+++ b/contracts/L2/Scarb.lock
@@ -6,6 +6,7 @@ name = "l2"
 version = "0.1.0"
 dependencies = [
  "openzeppelin_access",
+ "openzeppelin_introspection",
  "openzeppelin_token",
  "openzeppelin_upgrades",
  "openzeppelin_utils",

--- a/contracts/L2/Scarb.toml
+++ b/contracts/L2/Scarb.toml
@@ -8,6 +8,7 @@ edition = "2024_07"
 [dependencies]
 starknet = "2.9.2"
 openzeppelin_access = "0.20.0"
+openzeppelin_introspection = "0.20.0"
 openzeppelin_token = "0.20.0"
 openzeppelin_upgrades = "0.20.0"
 

--- a/contracts/L2/src/xZBERC20.cairo
+++ b/contracts/L2/src/xZBERC20.cairo
@@ -1,7 +1,7 @@
-use starknet::ContractAddress;
-
 // SPDX-License-Identifier: MIT
 // Compatible with OpenZeppelin Contracts for Cairo ^0.20.0
+
+use starknet::ContractAddress;
 
 #[starknet::interface]
 pub trait IMintable<TContractState> {
@@ -13,17 +13,24 @@ pub trait IBurnable<TContractState> {
     fn burn(ref self: TContractState, amount: u256);
 }
 
+pub const MINTER_ROLE: felt252 = selector!("MINTER_ROLE");
+pub const UPGRADER_ROLE: felt252 = selector!("UPGRADER_ROLE");
+
 #[starknet::contract]
 pub mod xZBERC20 {
-    use openzeppelin_access::ownable::OwnableComponent;
+    use openzeppelin_access::accesscontrol::{AccessControlComponent, DEFAULT_ADMIN_ROLE};
+    use openzeppelin_introspection::src5::SRC5Component;
     use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use openzeppelin_upgrades::UpgradeableComponent;
     use openzeppelin_upgrades::interface::IUpgradeable;
     use starknet::{ClassHash, ContractAddress, get_caller_address};
 
     use super::{IBurnable, IMintable};
+    use super::{MINTER_ROLE, UPGRADER_ROLE};
+
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);
-    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+    component!(path: AccessControlComponent, storage: accesscontrol, event: AccessControlEvent);
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
 
 
@@ -31,11 +38,12 @@ pub mod xZBERC20 {
     #[abi(embed_v0)]
     impl ERC20MixinImpl = ERC20Component::ERC20MixinImpl<ContractState>;
     #[abi(embed_v0)]
-    impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
+    impl AccessControlMixinImpl =
+        AccessControlComponent::AccessControlMixinImpl<ContractState>;
 
     // Internal
     impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
-    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+    impl AccessControlInternalImpl = AccessControlComponent::InternalImpl<ContractState>;
     impl UpgradeableInternalImpl = UpgradeableComponent::InternalImpl<ContractState>;
 
     #[storage]
@@ -43,7 +51,9 @@ pub mod xZBERC20 {
         #[substorage(v0)]
         erc20: ERC20Component::Storage,
         #[substorage(v0)]
-        ownable: OwnableComponent::Storage,
+        accesscontrol: AccessControlComponent::Storage,
+        #[substorage(v0)]
+        src5: SRC5Component::Storage,
         #[substorage(v0)]
         upgradeable: UpgradeableComponent::Storage,
     }
@@ -54,7 +64,9 @@ pub mod xZBERC20 {
         #[flat]
         ERC20Event: ERC20Component::Event,
         #[flat]
-        OwnableEvent: OwnableComponent::Event,
+        AccessControlEvent: AccessControlComponent::Event,
+        #[flat]
+        SRC5Event: SRC5Component::Event,
         #[flat]
         UpgradeableEvent: UpgradeableComponent::Event,
     }
@@ -62,13 +74,17 @@ pub mod xZBERC20 {
     #[constructor]
     fn constructor(ref self: ContractState, owner: ContractAddress) {
         self.erc20.initializer("xZB", "XZB");
-        self.ownable.initializer(owner);
+        self.accesscontrol.initializer();
+
+        self.accesscontrol._grant_role(DEFAULT_ADMIN_ROLE, owner);
+        self.accesscontrol._grant_role(UPGRADER_ROLE, owner);
+        self.accesscontrol._grant_role(MINTER_ROLE, owner);
     }
 
     #[abi(embed_v0)]
     impl MintableImpl of IMintable<ContractState> {
         fn mint(ref self: ContractState, recipient: ContractAddress, amount: u256) {
-            self.ownable.assert_only_owner();
+            self.accesscontrol.assert_only_role(MINTER_ROLE);
             self.erc20.mint(recipient, amount);
         }
     }
@@ -88,7 +104,7 @@ pub mod xZBERC20 {
     #[abi(embed_v0)]
     impl UpgradeableImpl of IUpgradeable<ContractState> {
         fn upgrade(ref self: ContractState, new_class_hash: ClassHash) {
-            self.ownable.assert_only_owner();
+            self.accesscontrol.assert_only_role(UPGRADER_ROLE);
             self.upgradeable.upgrade(new_class_hash);
         }
     }


### PR DESCRIPTION
- allow approved contracts to mint xZBERC20
- replace OwnableComponent by AccessControlComponent
- mint is restricted to MINTER_ROLE
- update related mint test
- add test for `grant_role`, `revoke_role` and `renounce_role`

Close #23 