### PR TITLE
feat(L2)#8: implement process_mint_proof

### DIFF
--- a/contracts/L2/Scarb.toml
+++ b/contracts/L2/Scarb.toml
@@ -6,6 +6,7 @@ edition = "2024_07"
 # See more keys and their definitions at https://docs.swmansion.com/scarb/docs/reference/manifest.html
 
 [dependencies]
+integrity = "2.0.0"
 starknet = "2.9.2"
 openzeppelin_access = "0.20.0"
 openzeppelin_introspection = "0.20.0"
@@ -22,3 +23,8 @@ sierra = true
 
 [scripts]
 test = "snforge test"
+
+[[tool.snforge.fork]]
+name = "SEPOLIA_LATEST"
+url = "https://starknet-sepolia.public.blastapi.io/rpc/v0_7"
+block_id.tag = "latest"

--- a/contracts/L2/src/ZeroXBridgeL2.cairo
+++ b/contracts/L2/src/ZeroXBridgeL2.cairo
@@ -1,19 +1,36 @@
 #[starknet::interface]
 pub trait IZeroXBridgeL2<TContractState> {
     fn burn_xzb_for_unlock(ref self: TContractState, amount: core::integer::u256);
+    /// The proof structure assumes the first three elements contain recipient, amount_low, and
+    /// amount_high.
+    fn process_mint_proof(
+        ref self: TContractState, proof: Array<felt252>, commitment_hash: felt252,
+    );
 }
 
 #[starknet::contract]
 pub mod ZeroXBridgeL2 {
+    use integrity::IntegrityWithConfigTrait;
+    use integrity::IntegrityTrait;
     use starknet::{ContractAddress, get_caller_address};
-    use l2::xZBERC20::{IBurnableDispatcher, IBurnableDispatcherTrait};
+    use l2::xZBERC20::{
+        IBurnableDispatcher, IBurnableDispatcherTrait, IMintableDispatcher,
+        IMintableDispatcherTrait,
+    };
     use core::pedersen::PedersenTrait;
-    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::storage::{
+        StoragePointerReadAccess, StoragePointerWriteAccess, Map, StorageMapReadAccess,
+        StorageMapWriteAccess,
+    };
     use core::hash::{HashStateTrait, HashStateExTrait};
+    use integrity::{Integrity, IntegrityWithConfig, VerifierConfiguration};
 
     #[storage]
     struct Storage {
         xzb_token: ContractAddress,
+        facts_registery_address: ContractAddress,
+        security_bits: u32,
+        verified_commitments: Map<felt252, bool>,
     }
 
     #[derive(Drop, Hash)]
@@ -23,10 +40,18 @@ pub mod ZeroXBridgeL2 {
         pub amount_high: felt252,
     }
 
+    #[derive(Drop, Hash)]
+    pub struct MintData {
+        pub recipient: felt252,
+        pub amount_low: felt252,
+        pub amount_high: felt252,
+    }
+
     #[event]
     #[derive(Drop, Debug, starknet::Event)]
     pub enum Event {
         BurnEvent: BurnEvent,
+        MintEvent: MintEvent,
     }
 
     #[derive(Drop, Debug, starknet::Event)]
@@ -37,9 +62,24 @@ pub mod ZeroXBridgeL2 {
         pub commitment_hash: felt252,
     }
 
+    #[derive(Drop, Debug, starknet::Event)]
+    pub struct MintEvent {
+        pub recipient: ContractAddress,
+        pub amount_low: felt252,
+        pub amount_high: felt252,
+        pub commitment_hash: felt252,
+    }
+
     #[constructor]
-    fn constructor(ref self: ContractState, token: ContractAddress) {
+    fn constructor(
+        ref self: ContractState,
+        token: ContractAddress,
+        facts_registery_address: ContractAddress,
+        security_bits: u32,
+    ) {
         self.xzb_token.write(token);
+        self.facts_registery_address.write(facts_registery_address);
+        self.security_bits.write(security_bits);
     }
 
     #[abi(embed_v0)]
@@ -65,6 +105,72 @@ pub mod ZeroXBridgeL2 {
                         amount_high: amount.high.into(),
                         commitment_hash: commitment_hash,
                     },
+                );
+        }
+
+        fn process_mint_proof(
+            ref self: ContractState, proof: Array<felt252>, commitment_hash: felt252,
+        ) {
+            assert(
+                !self.verified_commitments.read(commitment_hash), 'Commitment already processed',
+            );
+
+            let facts_registery = self.facts_registery_address.read();
+            let integrity = Integrity::from_address(facts_registery);
+
+            let config = VerifierConfiguration {
+                layout: 'recursive_with_poseidon',
+                hasher: 'keccak_160_lsb',
+                stone_version: 'stone6',
+                memory_verification: 'relaxed',
+            };
+
+            let integrity_with_config = integrity.with_config(config, self.security_bits.read());
+            assert(integrity_with_config.is_fact_hash_valid(commitment_hash), 'Invalid proof');
+
+            self.verified_commitments.write(commitment_hash, true);
+            assert(proof.len() >= 3, 'Proof too short');
+
+            let recipient_felt = *proof.at(0);
+            let amount_low = *proof.at(1);
+            let amount_high = *proof.at(2);
+
+            let recipient: ContractAddress = recipient_felt.try_into().unwrap();
+            let amount = core::integer::u256 {
+                low: amount_low.try_into().unwrap(), high: amount_high.try_into().unwrap(),
+            };
+
+            let mint_data = MintData { recipient: recipient_felt, amount_low, amount_high };
+
+            // At this point, the process should have went like this:
+            // (before calling the process_mint_proof)
+            // - 1. User generates a STARK proof with the `stone-prover`
+            // - 2. User serializes the proof into calldata alongside with the verifier config
+            // (reference:
+            // https://github.com/HerodotusDev/integrity/?tab=readme-ov-file#monolith-proof)
+            // - 3. Register the proof on Integrity's FactRegistry contract, verifier verifies that
+            // the proof is valid
+            // (https://github.com/HerodotusDev/integrity/blob/main/deployed_contracts.md)
+            //      and it computes our serialized calldata into a verification hash and stores it.
+            // (calling the process_mint_proof)
+            // - 4. Now that we have registered our fact, we call Inegrity's `is_fact_hash_valid()`
+            // function with our commitment hash,
+            //      if it is valid it finds a matching verification hash for it, it will return
+            //      `true`
+            // - 5. lastly, in this code we assert that the commitment hash matches what we want to
+            // prove (L145)
+
+            let computed_hash = PedersenTrait::new(0).update_with(mint_data).finalize();
+            assert(computed_hash == commitment_hash, 'Proof does not match commitment');
+
+            let token_addr = self.xzb_token.read();
+            IMintableDispatcher { contract_address: token_addr }.mint(recipient, amount);
+
+            self
+                .emit(
+                    Event::MintEvent(
+                        MintEvent { recipient, amount_low, amount_high, commitment_hash },
+                    ),
                 );
         }
     }


### PR DESCRIPTION

## Related issue #8 

## PR Description
This PR implements the `process_mint_proof` function for the ZeroXBridge L2 contract, enabling secure cross-chain transfers from Ethereum (L1) to Starknet (L2).

### Implementation Details
- Added `process_mint_proof` function that accepts a zkProof and commitment hash
- Integrated with Integrity verifier to validate proofs against the Facts Registry
- Implemented protection against replay attacks via commitment tracking
- Extracted and validated proof data (recipient address and amount)
- Added token minting functionality upon successful verification

### Testing
Added comprehensive test coverage for:
- Successful proof verification and token minting
- Duplicate commitment rejection
- Invalid proof detection
- Insufficient proof data handling

All tests pass successfully with appropriate gas usage.

### Design Considerations
The implementation follows a security-first approach, ensuring that:
1. Each commitment can only be processed once
2. The proof must be cryptographically validated through the Integrity verifier
3. The extracted data must match the commitment hash
4. Proper token minting occurs only after all validations succeed

---
This my favorite project to be contributing to so far from the OnlyDust platform. ZKPs are complex but so interesting, it made me learn a lot. Thank you very much for assigning me to  the issue! Also please tell me if I need to change/fix anything!
