### PR TITLE
Feat: implement L2 Merkle State Manager for withdrawals and deposit sync

### DIFF
--- a/contracts/L2/src/lib.cairo
+++ b/contracts/L2/src/lib.cairo
@@ -5,3 +5,4 @@ pub mod DAO;
 pub mod ZeroXBridgeL2;
 pub mod Dynamicrate;
 pub mod L2Oracle;
+pub mod merkle_state_manager;

--- a/contracts/L2/src/merkle_state_manager.cairo
+++ b/contracts/L2/src/merkle_state_manager.cairo
@@ -1,0 +1,99 @@
+#[starknet::interface]
+pub trait IMerkleStateManager<TContractState> {
+    fn update_withdrawal_root_from_commitment(ref self: TContractState, commitment: felt252);
+    fn sync_deposit_root_from_l1(ref self: TContractState, new_root: felt252);
+}
+
+#[starknet::contract]
+pub mod MerkleStateManager {
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess, Map, StorageMapWriteAccess};
+    use starknet::{get_block_timestamp, get_caller_address, ContractAddress};
+    use openzeppelin_access::ownable::OwnableComponent;
+
+    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
+
+    #[abi(embed_v0)]
+    impl OwnableMixinImpl = OwnableComponent::OwnableMixinImpl<ContractState>;
+
+    impl InternalImpl = OwnableComponent::InternalImpl<ContractState>;
+
+    #[storage]
+    struct Storage {
+        deposit_root: felt252,
+        withdrawal_root: felt252,
+        deposit_root_index: u64,
+        withdrawal_root_index: u64,
+        deposit_root_history: Map<u64, felt252>,
+        withdrawal_root_history: Map<u64, felt252>,
+        deposit_root_timestamp: Map<u64, u64>,
+        withdrawal_root_timestamp: Map<u64, u64>,
+        #[substorage(v0)]
+        ownable: OwnableComponent::Storage,
+        relayer: ContractAddress,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress, relayer: ContractAddress) {
+        self.ownable.initializer(owner);
+        self.relayer.write(relayer);
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        WithdrawalRootUpdated: WithdrawalRootUpdated,
+        DepositRootSynced: DepositRootSynced,
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct WithdrawalRootUpdated {
+        pub index: u64,
+        pub new_root: felt252,
+        pub commitment: felt252,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct DepositRootSynced {
+        pub index: u64,
+        pub new_root: felt252,
+    }
+
+    #[abi(embed_v0)]
+    impl MerkleStateManagerImpl of super::IMerkleStateManager<ContractState> {
+        fn update_withdrawal_root_from_commitment(ref self: ContractState, commitment: felt252) {
+            let current_index = self.withdrawal_root_index.read();
+            let new_index = current_index + 1;
+
+            self.withdrawal_root.write(commitment);
+            self.withdrawal_root_index.write(new_index);
+            self.withdrawal_root_history.write(new_index, commitment);
+            self.withdrawal_root_timestamp.write(new_index, get_block_timestamp());
+
+            self.emit(WithdrawalRootUpdated {
+                index: new_index,
+                new_root: commitment,
+                commitment,
+            });
+        }
+        fn sync_deposit_root_from_l1(ref self: ContractState, new_root: felt252) {
+            let caller = get_caller_address();
+            let is_authorized = self.ownable.owner() == caller || self.relayer.read() == caller;
+            assert(is_authorized, 'Caller not authorized');
+
+            let current_index = self.deposit_root_index.read();
+            let new_index = current_index + 1;
+
+            self.deposit_root.write(new_root);
+            self.deposit_root_index.write(new_index);
+            self.deposit_root_history.write(new_index, new_root);
+            self.deposit_root_timestamp.write(new_index, get_block_timestamp());
+
+            self.emit(DepositRootSynced {
+                index: new_index,
+                new_root,
+            });
+        }
+    }
+}

--- a/contracts/L2/tests/test_merkle_state_manager.cairo
+++ b/contracts/L2/tests/test_merkle_state_manager.cairo
@@ -1,0 +1,111 @@
+use snforge_std::ContractClassTrait;
+use openzeppelin_utils::serde::SerializedAppend;
+use snforge_std::DeclareResultTrait;
+use starknet::{ContractAddress, contract_address_const};
+use snforge_std::{
+    declare, start_cheat_caller_address,
+    stop_cheat_caller_address, EventSpyAssertionsTrait, spy_events,
+};
+use l2::merkle_state_manager::{MerkleStateManager, IMerkleStateManagerDispatcher, IMerkleStateManagerDispatcherTrait};
+
+fn deploy_merkle_state_manager(relayer: ContractAddress) -> (ContractAddress, ContractAddress) {
+    let contract_class = declare("MerkleStateManager").unwrap().contract_class();
+    let owner = contract_address_const::<'OWNER'>();
+    let mut calldata = array![];
+    calldata.append_serde(owner);
+    calldata.append_serde(relayer);
+    let (contract_address, _) = contract_class.deploy(@calldata).unwrap();
+    (contract_address, owner)
+}
+
+#[test]
+fn test_update_withdrawal_root_from_commitment() {
+    let relayer = contract_address_const::<'RELAYER'>();
+    let (contract_address, _) = deploy_merkle_state_manager(relayer);
+    let dispatcher = IMerkleStateManagerDispatcher { contract_address };
+    let mut spy = spy_events();
+
+    let commitment = 'COMMITMENT';
+    dispatcher.update_withdrawal_root_from_commitment(commitment);
+
+    let expected_event = MerkleStateManager::Event::WithdrawalRootUpdated(
+        MerkleStateManager::WithdrawalRootUpdated {
+            index: 1,
+            new_root: commitment,
+            commitment,
+        },
+    );
+
+    // Assert that the event was emitted
+    spy.assert_emitted(@array![(contract_address, expected_event)]);
+}
+
+#[test]
+fn test_sync_deposit_root_from_l1_owner() {
+    let relayer = contract_address_const::<'RELAYER'>();
+    let (contract_address, owner) = deploy_merkle_state_manager(relayer);
+    let dispatcher = IMerkleStateManagerDispatcher { contract_address };
+    let mut spy = spy_events();
+
+    // Start impersonating owner
+    start_cheat_caller_address(contract_address, owner);
+
+    let new_root = 'OWNER_ROOT';
+    dispatcher.sync_deposit_root_from_l1(new_root);
+
+    let expected_event = MerkleStateManager::Event::DepositRootSynced(
+        MerkleStateManager::DepositRootSynced {
+            index: 1,
+            new_root,
+        },
+    );
+
+    // Assert that the event was emitted
+    spy.assert_emitted(@array![(contract_address, expected_event)]);
+
+    stop_cheat_caller_address(contract_address);
+}
+
+#[test]
+fn test_sync_deposit_root_from_l1_relayer() {
+    let relayer = contract_address_const::<'RELAYER'>();
+    let (contract_address, _) = deploy_merkle_state_manager(relayer);
+    let dispatcher = IMerkleStateManagerDispatcher { contract_address };
+    let mut spy = spy_events();
+
+    // Start impersonating owner
+    start_cheat_caller_address(contract_address, relayer);
+
+    let new_root = 'RELAYER_ROOT';
+    dispatcher.sync_deposit_root_from_l1(new_root);
+
+    let expected_event = MerkleStateManager::Event::DepositRootSynced(
+        MerkleStateManager::DepositRootSynced {
+            index: 1,
+            new_root,
+        },
+    );
+
+    // Assert that the event was emitted
+    spy.assert_emitted(@array![(contract_address, expected_event)]);
+
+    stop_cheat_caller_address(contract_address);
+}
+
+#[test]
+#[should_panic(expected: ('Caller not authorized',))]
+fn test_sync_deposit_root_from_l1_non_owner() {
+    let relayer = contract_address_const::<'RELAYER'>();
+    let (contract_address, _) = deploy_merkle_state_manager(relayer);
+    let dispatcher = IMerkleStateManagerDispatcher { contract_address };
+
+    let non_owner_address = contract_address_const::<'NON_OWNER'>();
+
+    // Start impersonating owner
+    start_cheat_caller_address(contract_address, non_owner_address);
+
+    let new_root = 'NON_OWNER_ROOT';
+    dispatcher.sync_deposit_root_from_l1(new_root);
+
+    stop_cheat_caller_address(contract_address);
+}


### PR DESCRIPTION
Closes #64 

# Summary
- Implements `merkle_state_manager.cairo` according to the instructions in the issue description.
- Adds events to be emitted within each function implementation
- Adds tests in `test_merkle_state_manager.cairo` for testing the function implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a contract for managing Merkle state roots with versioning, history, timestamps, and access control for deposit and withdrawal roots.
  - Added events for tracking updates and syncs of Merkle roots.
- **Tests**
  - Added tests to verify event emissions and access control for Merkle state management functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->