### PR TITLE
Extend  to Verify Signature on Commitment Hash

### DIFF
--- a/contracts/L1/generateEthSignature.js
+++ b/contracts/L1/generateEthSignature.js
@@ -1,0 +1,93 @@
+import { ethers } from "ethers"; // Only import ethers, as arrayify is no longer a direct export
+
+// Load environment variables from .env file
+import dotenv from "dotenv";
+dotenv.config();
+
+/**
+ * Configuration for the script.
+ * Loads privateKey from environment variable.
+ */
+const config = {
+  privateKey: process.env.PRIVATE_KEY || "",
+  // The commitment hash must match what your Cairo contract expects.
+  commitmentHash: "0x12315b7aa9abd71d79ebe6926844e4612925f04edcd18eb9c687d517f8a674",
+};
+
+/**
+ * Signs a given commitment hash using an Ethereum wallet and returns the signature components.
+ * @param {string} privateKey - The private key of the Ethereum wallet.
+ * @param {string} commitmentHash - The hash to be signed (e.g., a Cairo commitment hash).
+ * @returns {Promise<Object>} An object containing eth_address, r, s, and y_parity.
+ */
+async function signCommitment(privateKey, commitmentHash) {
+  // 1. Initialize Wallet
+  // We don't need a provider for just signing a message locally.
+  const wallet = new ethers.Wallet(privateKey);
+  console.log("Wallet initialized with address:", wallet.address);
+
+  // 2. Prepare the message for signing
+  // ethers.js expects bytes for signMessage.
+  // In newer ethers.js v6, use ethers.getBytes instead of arrayify.
+  const messageBytes = ethers.getBytes(commitmentHash); // <<< --- IMPORTANT CHANGE HERE
+  console.log("Signing commitment hash:", commitmentHash);
+
+  // 3. Sign the message
+  const signature = await wallet.signMessage(messageBytes);
+  console.log("Raw Signature:", signature);
+
+  // 4. Extract signature components
+  // ethers.Signature.from parses the raw signature string into r, s, and v components.
+  const { r, s, v } = ethers.Signature.from(signature);
+
+  // Calculate y_parity (v % 2 === 1)
+  const yParity = v % 2 === 1;
+
+  return {
+    eth_address: wallet.address,
+    r: r,
+    s: s,
+    y_parity: yParity,
+  };
+}
+
+/**
+ * Main execution function.
+ * Handles the overall flow and error logging.
+ */
+async function main() {
+  try {
+    const { privateKey, commitmentHash } = config;
+
+    // Validate inputs (basic check)
+    if (!privateKey || !commitmentHash) {
+      throw new Error("Missing configuration: privateKey or commitmentHash.");
+    }
+    if (!privateKey.startsWith("0x")) {
+      console.warn("Warning: Private key does not start with '0x'. Ethers.js usually handles this, but it's good practice to include it.");
+    }
+    if (!commitmentHash.startsWith("0x")) {
+        throw new Error("Commitment hash must be a hex string and start with '0x'.");
+    }
+
+    const result = await signCommitment(privateKey, commitmentHash);
+
+    console.log("\n--- Signature Details ---");
+    console.log("eth_address:", result.eth_address);
+    console.log("r:", result.r);
+    console.log("s:", result.s);
+    console.log("y_parity:", result.y_parity);
+    console.log("-------------------------");
+
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(error.message);
+    } else {
+      console.error(error);
+    }
+    process.exit(1); // Exit with a non-zero code to indicate failure
+  }
+}
+
+// Execute the main function
+main();

--- a/contracts/L1/generateEthSignature.ts
+++ b/contracts/L1/generateEthSignature.ts
@@ -1,0 +1,92 @@
+import { ethers } from "ethers"; // Only import ethers, as arrayify is no longer a direct export
+
+// Load environment variables from .env file
+import dotenv from "dotenv";
+dotenv.config();
+
+/**
+ * Configuration for the script.
+ * Loads privateKey from environment variable.
+ */
+const config = {
+  privateKey: process.env.PRIVATE_KEY || "",
+  // The commitment hash must match what your Cairo contract expects.
+  commitmentHash: "0x12315b7aa9abd71d79ebe6926844e4612925f04edcd18eb9c687d517f8a674",
+};
+
+/**
+ * Signs a given commitment hash using an Ethereum wallet and returns the signature components.
+ * @param {string} privateKey - The private key of the Ethereum wallet.
+ * @param {string} commitmentHash - The hash to be signed (e.g., a Cairo commitment hash).
+ * @returns {Promise<Object>} An object containing eth_address, r, s, and y_parity.
+ */
+async function signCommitment(privateKey, commitmentHash) {
+  // 1. Initialize Wallet
+  // We don't need a provider for just signing a message locally.
+  const wallet = new ethers.Wallet(privateKey);
+  console.log("Wallet initialized with address:", wallet.address);
+
+  // 2. Prepare the message for signing
+  // ethers.js expects bytes for signMessage.
+  // In newer ethers.js v6, use ethers.getBytes instead of arrayify.
+  const messageBytes = ethers.getBytes(commitmentHash); // <<< --- IMPORTANT CHANGE HERE
+  console.log("Signing commitment hash:", commitmentHash);
+
+  // 3. Sign the message
+  const signature = await wallet.signMessage(messageBytes);
+  console.log("Raw Signature:", signature);
+
+  // 4. Extract signature components
+  // ethers.Signature.from parses the raw signature string into r, s, and v components.
+  const { r, s, v } = ethers.Signature.from(signature);
+
+  // Calculate y_parity (v % 2 === 1)
+  const yParity = v % 2 === 1;
+
+  return {
+    eth_address: wallet.address,
+    r: r,
+    s: s,
+    y_parity: yParity,
+  };
+}
+
+/**
+ * Main execution function.
+ * Handles the overall flow and error logging.
+ */
+async function main() {
+  try {
+    const { privateKey, commitmentHash } = config;
+
+    // Validate inputs (basic check)
+    if (!privateKey || !commitmentHash) {
+      throw new Error("Missing configuration: privateKey or commitmentHash.");
+    }
+    if (!privateKey.startsWith("0x")) {
+      console.warn("Warning: Private key does not start with '0x'. Ethers.js usually handles this, but it's good practice to include it.");
+    }
+    if (!commitmentHash.startsWith("0x")) {
+        throw new Error("Commitment hash must be a hex string and start with '0x'.");
+    }
+
+    const result = await signCommitment(privateKey, commitmentHash);
+
+    console.log("\n--- Signature Details ---");
+    console.log("eth_address:", result.eth_address);
+    console.log("r:", result.r);
+    console.log("s:", result.s);
+    console.log("y_parity:", result.y_parity);
+    console.log("-------------------------");
+
+  } catch (error) {
+    console.error("\nAn error occurred:");
+    console.error(error.message);
+    // Log the whole error object for more details if needed
+    // console.error(error);
+    process.exit(1); // Exit with a non-zero code to indicate failure
+  }
+}
+
+// Execute the main function
+main();

--- a/contracts/L2/.gitignore
+++ b/contracts/L2/.gitignore
@@ -1,3 +1,4 @@
 target
 .snfoundry_cache/
 .tool-versions
+node_modules

--- a/contracts/L2/package-lock.json
+++ b/contracts/L2/package-lock.json
@@ -1,0 +1,670 @@
+{
+  "name": "l2",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "l2",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "ethers": "^6.14.3",
+        "starknet": "^6.24.1"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.1.tgz",
+      "integrity": "sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/starknet": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scure/starknet/-/starknet-1.1.0.tgz",
+      "integrity": "sha512-83g3M6Ix2qRsPN4wqLDqiRZ2GBNbjVWfboJE/9UjfG+MHr6oDSu/CWgy8hsBSJejr09DkkL+l0Ze4KVrlCIdtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.7.0",
+        "@noble/hashes": "~1.6.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/starknet/node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/starknet/node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/starknet/node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/abi-wan-kanabi": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/abi-wan-kanabi/-/abi-wan-kanabi-2.2.4.tgz",
+      "integrity": "sha512-0aA81FScmJCPX+8UvkXLki3X1+yPQuWxEkqXBVKltgPAK79J+NB+Lp5DouMXa7L6f+zcRlIA/6XO7BN/q9fnvg==",
+      "license": "ISC",
+      "dependencies": {
+        "ansicolors": "^0.3.2",
+        "cardinal": "^2.1.1",
+        "fs-extra": "^10.0.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "generate": "dist/generate.js"
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansicolors": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
+      "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
+      "license": "MIT"
+    },
+    "node_modules/cardinal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
+      "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansicolors": "~0.3.2",
+        "redeyed": "~2.1.0"
+      },
+      "bin": {
+        "cdl": "bin/cdl.js"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ethers": {
+      "version": "6.14.3",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.14.3.tgz",
+      "integrity": "sha512-qq7ft/oCJohoTcsNPFaXSQUm457MA5iWqkf1Mb11ujONdg7jBI6sAOrHaTi3j0CBqIGFSCeR/RMc+qwRRub7IA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/fetch-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-3.0.1.tgz",
+      "integrity": "sha512-ZGXe8Y5Z/1FWqQ9q/CrJhkUD73DyBU9VF0hBQmEO/wPHe4A9PKTjplFDLeFX8aOsYypZUcX5Ji/eByn3VCVO3Q==",
+      "license": "Unlicense",
+      "dependencies": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lossless-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.1.0.tgz",
+      "integrity": "sha512-DgoRs42jH/yNubp8iinRqvG0xn5awHKXVY+7lGYjBaByoHGZt/Dz5Jkaf5znP2XHbTnAA+bbkhK3lMIaf3+92A==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
+    "node_modules/redeyed": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
+      "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "esprima": "~4.0.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
+    },
+    "node_modules/starknet": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-6.24.1.tgz",
+      "integrity": "sha512-g7tiCt73berhcNi41otlN3T3kxZnIvZhMi8WdC21Y6GC6zoQgbI2z1t7JAZF9c4xZiomlanwVnurcpyfEdyMpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.7.0",
+        "@noble/hashes": "1.6.0",
+        "@scure/base": "1.2.1",
+        "@scure/starknet": "1.1.0",
+        "abi-wan-kanabi": "^2.2.3",
+        "fetch-cookie": "~3.0.0",
+        "isomorphic-fetch": "~3.0.0",
+        "lossless-json": "^4.0.1",
+        "pako": "^2.0.4",
+        "starknet-types-07": "npm:@starknet-io/types-js@^0.7.10",
+        "ts-mixer": "^6.0.3"
+      }
+    },
+    "node_modules/starknet-types-07": {
+      "name": "@starknet-io/types-js",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
+      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
+      "license": "MIT"
+    },
+    "node_modules/starknet/node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/starknet/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/contracts/L2/package.json
+++ b/contracts/L2/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "l2",
+  "version": "1.0.0",
+  "description": "## Sepolia",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "gen-signature": "npx esrun scripts/sign.ts",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "ethers": "^6.14.3",
+    "starknet": "^6.24.1"
+  }
+}

--- a/contracts/L2/scripts/sign.ts
+++ b/contracts/L2/scripts/sign.ts
@@ -1,0 +1,37 @@
+import { ethers } from "ethers";
+
+async function signMessage() {
+  // Create a random wallet for testing
+  const wallet = ethers.Wallet.createRandom();
+  console.log("Wallet address:", wallet.address);
+
+  // Message to sign
+  const commitmentHash =
+    "0x12315b7aa9abd71d79ebe6926844e4612925f04edcd18eb9c687d517f8a674";
+
+  console.log("Commitment hash:", commitmentHash);
+
+  // Sign the message
+  const signature = await wallet.signMessage(commitmentHash);
+  console.log("Signature:", signature);
+
+  // Split the signature into r, s, v components
+  const signatureBytes = ethers.getBytes(signature);
+  const r = ethers.hexlify(signatureBytes.slice(0, 32));
+  const s = ethers.hexlify(signatureBytes.slice(32, 64));
+  const v = signatureBytes[64];
+
+  console.log("r:", r);
+  console.log("s:", s);
+  console.log("v:", v);
+
+  // Verify the signature
+  const recoveredAddress = ethers.verifyMessage(commitmentHash, signature);
+  console.log("Recovered signer address:", recoveredAddress);
+  console.log("Signature verification:", recoveredAddress === wallet.address);
+}
+
+// Execute the function
+signMessage().catch((error) => {
+  console.error("Error:", error);
+});

--- a/contracts/L2/src/core/ZeroXBridgeL2.cairo
+++ b/contracts/L2/src/core/ZeroXBridgeL2.cairo
@@ -6,7 +6,13 @@ pub trait IZeroXBridgeL2<TContractState> {
     /// The proof structure assumes the first four elements contain recipient, usd_amount,
     /// block_hash
     fn mint_and_claim_xzb(
-        ref self: TContractState, proof: Array<felt252>, commitment_hash: felt252,
+        ref self: TContractState,
+        proof: Array<felt252>,
+        commitment_hash: felt252,
+        eth_address: felt252,
+        r: u256,
+        s: u256,
+        y_parity: bool,
     );
 
     fn burn_xzb_for_unlock(ref self: TContractState, amount: core::integer::u256);
@@ -46,6 +52,9 @@ pub mod ZeroXBridgeL2 {
     };
     use core::hash::{HashStateTrait, HashStateExTrait};
     use l2::core::ProofRegistry::{IProofRegistryDispatcher, IProofRegistryDispatcherTrait};
+    use starknet::eth_address::EthAddress;
+    use starknet::eth_signature::verify_eth_signature;
+    use starknet::secp256_trait::Signature;
 
     const PRECISION: u256 = 1_000_000_000_000_000_000; // 18 decimals for precision
 
@@ -181,13 +190,27 @@ pub mod ZeroXBridgeL2 {
     #[abi(embed_v0)]
     impl MintBurnXzbImpl of super::IZeroXBridgeL2<ContractState> {
         fn mint_and_claim_xzb(
-            ref self: ContractState, proof: Array<felt252>, commitment_hash: felt252,
+            ref self: ContractState,
+            proof: Array<felt252>,
+            commitment_hash: felt252,
+            eth_address: felt252,
+            r: u256,
+            s: u256,
+            y_parity: bool,
         ) {
             assert(
                 !self.verified_commitments.read(commitment_hash), 'Commitment already processed',
             );
 
             assert(proof.len() >= 4, 'Proof too short');
+
+            // Verify the signature over the commitment_hash
+            let msg_hash: u256 = commitment_hash.into();
+            let signature = Signature { r, s, y_parity };
+            let eth_addr: EthAddress = eth_address.try_into().unwrap();
+
+            // This will panic if the signature is invalid
+            verify_eth_signature(msg_hash, signature, eth_addr);
 
             let recipient_felt = *proof.at(0);
             let amount = *proof.at(1);

--- a/contracts/L2/src/core/ZeroXBridgeL2.cairo
+++ b/contracts/L2/src/core/ZeroXBridgeL2.cairo
@@ -198,21 +198,20 @@ pub mod ZeroXBridgeL2 {
             s: u256,
             y_parity: bool,
         ) {
-            // Check proof length first
+            // Always check proof length first to avoid out-of-bounds and undefined behavior
             assert(proof.len() >= 4, 'Proof too short');
 
-            // Check for duplicate commitment
-            assert(
-                !self.verified_commitments.read(commitment_hash), 'Commitment already processed',
-            );
-
-            // Verify the signature over the commitment_hash
+            // Then verify the signature for security
             let msg_hash: u256 = commitment_hash.into();
             let signature = Signature { r, s, y_parity };
             let eth_addr: EthAddress = eth_address.try_into().unwrap();
-
             // This will panic if the signature is invalid
             verify_eth_signature(msg_hash, signature, eth_addr);
+
+            // Now check for duplicate commitment
+            assert(
+                !self.verified_commitments.read(commitment_hash), 'Commitment already processed',
+            );
 
             let recipient_felt = *proof.at(0);
             let amount = *proof.at(1);

--- a/contracts/L2/src/core/ZeroXBridgeL2.cairo
+++ b/contracts/L2/src/core/ZeroXBridgeL2.cairo
@@ -204,9 +204,9 @@ pub mod ZeroXBridgeL2 {
             // Then verify the signature for security
             let msg_hash: u256 = commitment_hash.into();
             let signature = Signature { r, s, y_parity };
-            let eth_addr: EthAddress = eth_address.try_into().unwrap();
-            // This will panic if the signature is invalid
-            verify_eth_signature(msg_hash, signature, eth_addr);
+            let eth_address: EthAddress = eth_address.try_into().unwrap();
+
+            verify_eth_signature(msg_hash, signature, eth_address);
 
             // Now check for duplicate commitment
             assert(

--- a/contracts/L2/src/core/ZeroXBridgeL2.cairo
+++ b/contracts/L2/src/core/ZeroXBridgeL2.cairo
@@ -198,11 +198,13 @@ pub mod ZeroXBridgeL2 {
             s: u256,
             y_parity: bool,
         ) {
+            // Check proof length first
+            assert(proof.len() >= 4, 'Proof too short');
+
+            // Check for duplicate commitment
             assert(
                 !self.verified_commitments.read(commitment_hash), 'Commitment already processed',
             );
-
-            assert(proof.len() >= 4, 'Proof too short');
 
             // Verify the signature over the commitment_hash
             let msg_hash: u256 = commitment_hash.into();

--- a/contracts/L2/tests/test_ZeroXBridgeL2.cairo
+++ b/contracts/L2/tests/test_ZeroXBridgeL2.cairo
@@ -275,7 +275,7 @@ fn test_process_mint_proof_happy_path() {
     };
     let commitment_hash = PedersenTrait::new(0).update_with(mint_data).finalize();
 
-    // Print the commitment hash for use in JS
+    // Print the commitment hash for use in JS signature generation
     println!("commitment_hash: {:x}", commitment_hash);
 
     // Create spy to track events
@@ -295,11 +295,11 @@ fn test_process_mint_proof_happy_path() {
     // cheat_caller_address(token_addr, owner, CheatSpan::TargetCalls(1));
     cheat_caller_address(bridge_addr, owner, CheatSpan::TargetCalls(1));
 
-    // Dummy values for eth_address, r, s, y_parity for test purposes
-    let eth_address = 0xe80ef3b97e17BC5Ea1c1b79791B955342c68B47e.try_into().unwrap();
-    let r: u256 = 0x3e2db63f85f6dcd44aaee9c340361553feda42a98b4415653a5d6a966f8ead4b;
-    let s: u256 = 0x6e7edbe04d55d51ea77a0cab20995f2fc259726954a9ac93d57009be98d49001;
-    let y_parity: bool = false;
+    // Use valid signature values generated for the commitment hash
+    let eth_address = 0x30a12890B3c5535f714a33d89943eDf007dbb845.try_into().unwrap();
+    let r: u256 = 0x4ac6858340139bb74d09091f14a5cb67ab6a63b2bc3e217d931322af84a04a7a;
+    let s: u256 = 0x73ded3366f388b39c5f28db1df7c128264d1e8fce3e66053b2e9b1adedda4753;
+    let y_parity: bool = true;
     let commitment_hash = 0x12315b7aa9abd71d79ebe6926844e4612925f04edcd18eb9c687d517f8a674;
 
     IZeroXBridgeL2Dispatcher { contract_address: bridge_addr }
@@ -381,7 +381,10 @@ fn test_duplicate_commitment_rejection() {
     cheat_caller_address(bridge_addr, owner, CheatSpan::TargetCalls(1));
 
     // Use the same valid signature for both calls
-    let (eth_address, r, s, y_parity) = mock_valid_signature(commitment_hash);
+    let eth_address = 0x30a12890B3c5535f714a33d89943eDf007dbb845.try_into().unwrap();
+    let r: u256 = 0x4ac6858340139bb74d09091f14a5cb67ab6a63b2bc3e217d931322af84a04a7a;
+    let s: u256 = 0x73ded3366f388b39c5f28db1df7c128264d1e8fce3e66053b2e9b1adedda4753;
+    let y_parity: bool = true;
     IZeroXBridgeL2Dispatcher { contract_address: bridge_addr }
         .mint_and_claim_xzb(proof.clone(), commitment_hash, eth_address, r, s, y_parity);
     IZeroXBridgeL2Dispatcher { contract_address: bridge_addr }

--- a/contracts/L2/tests/test_ZeroXBridgeL2.cairo
+++ b/contracts/L2/tests/test_ZeroXBridgeL2.cairo
@@ -292,8 +292,16 @@ fn test_process_mint_proof_happy_path() {
     // cheat_caller_address(token_addr, owner, CheatSpan::TargetCalls(1));
     cheat_caller_address(bridge_addr, owner, CheatSpan::TargetCalls(1));
 
+    // Dummy values for eth_address, r, s, y_parity for test purposes
+    let eth_address = 0x767410c1bb448978bd42b984d7de5970bcaf5c43_u256
+    .try_into()
+    .unwrap();
+    let r: u256 = 0x4c8e4fbc1fbb1dece52185e532812c4f7a5f81cf3ee10044320a0d03b62d3e9a;
+    let s: u256 = 0x4ac5e5c0c0e8a4871583cc131f35fb49c2b7f60e6a8b84965830658f08f7410c;
+    let y_parity: bool = true;
+
     IZeroXBridgeL2Dispatcher { contract_address: bridge_addr }
-        .mint_and_claim_xzb(proof, commitment_hash);
+        .mint_and_claim_xzb(proof, commitment_hash, eth_address, r, s, y_parity);
 
     // Build expected event
     let expected_event = (
@@ -360,11 +368,21 @@ fn test_duplicate_commitment_rejection() {
     // cheat_caller_address(token_addr, owner, CheatSpan::TargetCalls(1));
     cheat_caller_address(bridge_addr, owner, CheatSpan::TargetCalls(1));
 
+    let eth_address= 0x767410c1bb448978bd42b984d7de5970bcaf5c43_u256
+    .try_into()
+    .unwrap();
+    let r: u256 = 0x4c8e4fbc1fbb1dece52185e532812c4f7a5f81cf3ee10044320a0d03b62d3e9a;
+    let s: u256 = 0x4ac5e5c0c0e8a4871583cc131f35fb49c2b7f60e6a8b84965830658f08f7410c;
+    let y_parity: bool = true;
     IZeroXBridgeL2Dispatcher { contract_address: bridge_addr }
-        .mint_and_claim_xzb(proof.clone(), commitment_hash);
+        .mint_and_claim_xzb(proof.clone(), commitment_hash, eth_address, r, s, y_parity);
+    let eth_address: felt252 = 0;
+    let r: u256 = 0x1_u256;
+    let s: u256 = 0x1_u256;
+    let y_parity: bool = true;
 
     IZeroXBridgeL2Dispatcher { contract_address: bridge_addr }
-        .mint_and_claim_xzb(proof, commitment_hash);
+        .mint_and_claim_xzb(proof, commitment_hash, eth_address, r, s, y_parity);
 }
 
 #[test]
@@ -402,7 +420,16 @@ fn test_insufficient_proof_data() {
 
     // cheat_caller_address(token_addr, owner, CheatSpan::TargetCalls(1));
     cheat_caller_address(bridge_addr, owner, CheatSpan::TargetCalls(1));
+
+    // Dummy values for eth_address, r, s, y_parity for test purposes
+    let eth_address = 0x767410c1bb448978bd42b984d7de5970bcaf5c43_u256
+    .try_into()
+    .unwrap();
+    let r: u256 = 0x4c8e4fbc1fbb1dece52185e532812c4f7a5f81cf3ee10044320a0d03b62d3e9a;
+    let s: u256 = 0x4ac5e5c0c0e8a4871583cc131f35fb49c2b7f60e6a8b84965830658f08f7410c;
+    let y_parity: bool = true;
+
     IZeroXBridgeL2Dispatcher { contract_address: bridge_addr }
-        .mint_and_claim_xzb(proof, commitment_hash);
+        .mint_and_claim_xzb(proof, commitment_hash, eth_address, r, s, y_parity);
 }
 


### PR DESCRIPTION
close #82
Summary
This PR enhances the mint_and_claim_xzb function in the L2 Bridge contract to require and verify an Ethereum signature over the commitment_hash. This ensures that only users who have authorized the claim on L1 can mint tokens on L2, improving security and preventing unauthorized claims.

Changes
Function Signature Update:
The mint_and_claim_xzb function now accepts additional parameters:

eth_address (Ethereum address of signer)
r, s (signature components)
y_parity (signature parity bit)
Signature Verification:
The function uses Cairo’s built-in verify_eth_signature to validate the signature over the commitment_hash using the provided Ethereum address.

Order of Checks:
The function first checks for duplicate commitments, then verifies the signature, then processes the mint.

Test Updates:
Tests were updated to generate and pass valid Ethereum signatures over the correct hash, and to check for failure on invalid signatures or duplicate commitments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Ethereum signature verification when minting and claiming tokens, requiring users to provide an Ethereum address and signature components.
  - Introduced scripts to generate and verify Ethereum signatures for commitment hashes.

- **Tests**
  - Updated tests to support the new Ethereum signature parameters in the mint and claim process.
  - Added tests to validate rejection of invalid signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->