### PR TITLE
feat: add helper for mmr indices

### DIFF
--- a/contracts/L1/test/MerkleManager.t.sol
+++ b/contracts/L1/test/MerkleManager.t.sol
@@ -80,6 +80,113 @@ contract MerkleManagerTest is Test {
         );
     }
 
+    /// @notice Test that verifies correct MMR indices are stored for commitments
+    function testCorrectMMRIndicesStored() public {
+        // Expected MMR indices for first 6 leaves according to MMR structure
+        // Leaf 0 -> MMR index 0
+        // Leaf 1 -> MMR index 1
+        // Leaf 2 -> MMR index 3 (index 2 is internal node)
+        // Leaf 3 -> MMR index 4
+        // Leaf 4 -> MMR index 7 (indices 5,6 are internal nodes)
+        // Leaf 5 -> MMR index 8
+        uint256[] memory expectedIndices = new uint256[](6);
+        expectedIndices[0] = 0;
+        expectedIndices[1] = 1;
+        expectedIndices[2] = 3;
+        expectedIndices[3] = 4;
+        expectedIndices[4] = 7;
+        expectedIndices[5] = 8;
+
+        bytes32[] memory commitments = new bytes32[](6);
+
+        // Add leaves one by one and verify stored indices
+        for (uint256 i = 0; i < 6; i++) {
+            commitments[i] = keccak256(abi.encode("commitment", i));
+            merkleManager.appendDepositHashPublic(commitments[i]);
+
+            uint256 storedIndex = merkleManager.getCommitmentIndex(commitments[i]);
+
+            assertEq(
+                storedIndex, expectedIndices[i], string(abi.encodePacked("Wrong MMR index for leaf ", vm.toString(i)))
+            );
+        }
+    }
+
+    /// @notice Test batch append with correct MMR index assignment
+    function testBatchAppendCorrectIndices() public {
+        bytes32[] memory batchCommitments = new bytes32[](4);
+        for (uint256 i = 0; i < 4; i++) {
+            batchCommitments[i] = keccak256(abi.encode("batch", i));
+        }
+
+        // Expected indices for batch: 0, 1, 3, 4
+        uint256[] memory expectedBatchIndices = new uint256[](4);
+        expectedBatchIndices[0] = 0;
+        expectedBatchIndices[1] = 1;
+        expectedBatchIndices[2] = 3;
+        expectedBatchIndices[3] = 4;
+
+        merkleManager.multiAppendDepositHashPublic(batchCommitments);
+
+        for (uint256 i = 0; i < 4; i++) {
+            uint256 storedIndex = merkleManager.getCommitmentIndex(batchCommitments[i]);
+            console.log("Batch leaf", i, "stored at MMR index:", storedIndex);
+
+            assertEq(storedIndex, expectedBatchIndices[i], "Wrong MMR index in batch append");
+        }
+    }
+
+    /// @notice Test edge case: first leaf gets index 0
+    function testFirstLeafIndexZero() public {
+        bytes32 firstCommitment = keccak256("first");
+        merkleManager.appendDepositHashPublic(firstCommitment);
+
+        uint256 index = merkleManager.getCommitmentIndex(firstCommitment);
+        assertEq(index, 0, "First leaf must have index 0");
+
+        console.log("First leaf correctly assigned index 0");
+    }
+
+    /// @notice Test mixed sequential and batch appends maintain correct indices
+    function testMixedAppendMaintainsCorrectIndices() public {
+        // Add 2 sequential
+        bytes32 seq1 = keccak256("seq1");
+        bytes32 seq2 = keccak256("seq2");
+        merkleManager.appendDepositHashPublic(seq1);
+        merkleManager.appendDepositHashPublic(seq2);
+
+        // Add 2 in batch
+        bytes32[] memory batch = new bytes32[](2);
+        batch[0] = keccak256("batch1");
+        batch[1] = keccak256("batch2");
+        merkleManager.multiAppendDepositHashPublic(batch);
+
+        // Verify indices: 0, 1, 3, 4
+        assertEq(merkleManager.getCommitmentIndex(seq1), 0, "seq1 wrong index");
+        assertEq(merkleManager.getCommitmentIndex(seq2), 1, "seq2 wrong index");
+        assertEq(merkleManager.getCommitmentIndex(batch[0]), 3, "batch1 wrong index");
+        assertEq(merkleManager.getCommitmentIndex(batch[1]), 4, "batch2 wrong index");
+
+        console.log(" Mixed append maintains correct MMR indices");
+    }
+
+    /// @notice Test that uncommitted hashes return index 0 (default)
+    function testUncommittedHashReturnsZero() public {
+        bytes32 nonExistentHash = keccak256("doesnotexist");
+        uint256 index = merkleManager.getCommitmentIndex(nonExistentHash);
+        assertEq(index, 0, "Non-existent hash should return 0");
+
+        // Add one commitment to make sure index 0 is now taken
+        bytes32 realCommitment = keccak256("real");
+        merkleManager.appendDepositHashPublic(realCommitment);
+
+        // Non-existent should still return 0 (this is a limitation to be aware of)
+        uint256 stillZero = merkleManager.getCommitmentIndex(nonExistentHash);
+        assertEq(stillZero, 0, "Non-existent hash still returns 0 after commits");
+
+        console.log(" Note: Non-existent hashes return 0, same as first valid commitment");
+    }
+
     /// @notice Logs the current peaks of the Merkle tree
     function logPeaks() internal view {
         bytes32[] memory peaks = merkleManager.getLastPeaks();

--- a/contracts/L1/test/mocks/MerkleManagerMock.sol
+++ b/contracts/L1/test/mocks/MerkleManagerMock.sol
@@ -22,7 +22,7 @@ contract MerkleMockManager is MerkleManager {
      * Updates peaks, root, and mappings for each. Emits DepositHashAppended for each.
      * @param commitmentHashes Array of deposit commitment hashes to append.
      */
-    function multiAppendDepositHashPublic(bytes32[] memory commitmentHashes) internal {
+    function multiAppendDepositHashPublic(bytes32[] memory commitmentHashes) public {
         multiAppendDepositHash(commitmentHashes);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Merkle Mountain Range index calculation for deposit commitments, ensuring accurate mapping of commitment hashes to their correct MMR leaf indices.

* **Bug Fixes**
  * Improved handling of edge cases when querying indices for non-existent commitment hashes.

* **Tests**
  * Added comprehensive tests to verify correct MMR index assignments for sequential, batch, and mixed appends, as well as edge cases.
  * Increased test coverage for querying uncommitted hashes and first-leaf scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->