### PR TITLE
Feat: include depositId in depositAsset and emit single enriched DepositEvent

### DIFF
--- a/contracts/L1/src/MerkleManager.sol
+++ b/contracts/L1/src/MerkleManager.sol
@@ -42,8 +42,14 @@ contract MerkleManager {
      * @dev Appends a new deposit commitment to the tree.
      * Updates peaks, root, and mappings. Emits DepositHashAppended.
      * @param commitmentHash The hash of the deposit commitment to append.
+     * @return newRoot The updated MMR root hash after the commitment is appended.
+     * @return newLeavesCount The total number of deposit leaves after this append operation.
+     * @return elementCount The total number of elements in the MMR after this append operation (including non-leaf nodes).
      */
-    function appendDepositHash(bytes32 commitmentHash) internal {
+    function appendDepositHash(bytes32 commitmentHash)
+        internal
+        returns (bytes32 newRoot, uint256 newLeavesCount, uint256 elementCount)
+    {
         // Append element to the tree and retrieve updated peaks and root
         (uint256 nextElementsCount, bytes32 nextRootHash, bytes32[] memory nextPeaks) =
             StatelessMmr.appendWithPeaksRetrieval(commitmentHash, lastPeaks, lastElementsCount, lastRoot);
@@ -59,9 +65,9 @@ contract MerkleManager {
         uint256 mmrLeafIndex = leafCountToMmrIndex(leavesCount);
         commitmentHashToIndex[commitmentHash] = mmrLeafIndex + 1; // +1 to make it 1-based index
         leavesCount += 1;
-
-        // Emit event for the appended deposit
-        emit DepositHashAppended(leavesCount, commitmentHash, lastRoot, lastElementsCount);
+        newRoot = lastRoot;
+        newLeavesCount = leavesCount;
+        elementCount = lastElementsCount;
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR refactors the deposit flow to emit a single DepositEvent with all necessary data, simplifying off-chain indexing.

## Changes
- Updated depositAsset to accept a depositId generated off-chain.
- Included depositId in the commitmentHash.
- Modified appendDepositHash to return (newRoot, leavesCount, elementCount).
- Removed the DepositHashAppended event emission.
- Emitted a single enriched DepositEvent containing deposit ID, token, asset type, USD value, user, nonce, commitment hash, Merkle root, and count.
- Updated relevant unit and integration tests.

Verification
- All tests pass 
<img width="868" height="1056" alt="image" src="https://github.com/user-attachments/assets/a8c83d28-8773-475b-bd25-b582cb192b2a" />

## Closes

Closes #107 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deposit events now include deposit ID, nonce, new Merkle root, and element count for improved deposit tracking and transparency.
  * The deposit function requires a deposit ID and returns enhanced Merkle tree state information.
* **Bug Fixes**
  * Tests updated to verify correct event emission and Merkle tree state after deposits.
* **Tests**
  * Expanded test coverage to validate new deposit parameters and event fields, ensuring accurate Merkle root and element count tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->