### PR TITLE
chore: fix build and tests

### DIFF
--- a/contracts/L2/src/core/ZeroXBridgeL2.cairo
+++ b/contracts/L2/src/core/ZeroXBridgeL2.cairo
@@ -134,6 +134,7 @@ pub mod ZeroXBridgeL2 {
 
     #[derive(Drop, Debug, starknet::Event)]
     pub struct BurnEvent {
+        pub burn_id: u256,
         pub user: ContractAddress,
         pub amount: u256,
         pub nonce: felt252,
@@ -241,7 +242,7 @@ pub mod ZeroXBridgeL2 {
         }
 
 
-        fn burn_xzb_for_unlock(ref self: ContractState, amount: u256) {
+        fn burn_xzb_for_unlock(ref self: ContractState, burn_id: u256, amount: u256) {
             let caller = get_caller_address();
             let token_addr = self.xzb_token.read();
             let protocol = get_contract_address();
@@ -277,6 +278,7 @@ pub mod ZeroXBridgeL2 {
             self
                 .emit(
                     BurnEvent {
+                        burn_id,
                         user: caller,
                         amount: burn_amount_usd,
                         nonce: current_nonce,
@@ -479,7 +481,7 @@ pub mod ZeroXBridgeL2 {
             // Clear all existing peaks from storage
             let current_len = self.last_peaks.len();
             for _i in 0..current_len {
-                self.last_peaks.pop();
+                let _ = self.last_peaks.pop();
             }
         }
 

--- a/contracts/L2/src/core/xZBERC20.cairo
+++ b/contracts/L2/src/core/xZBERC20.cairo
@@ -94,7 +94,7 @@ pub mod xZBERC20 {
 
     #[generate_trait]
     #[abi(per_item)]
-    impl TestMint of IxZbTest<ContractState> {
+    impl TestMint of IxZbTest {
         #[external(v0)]
         fn test_mint(ref self: ContractState, recipient: ContractAddress, amount: u256) {
             self.erc20.mint(recipient, amount);

--- a/contracts/L2/src/interfaces/IZeroXBridgeL2.cairo
+++ b/contracts/L2/src/interfaces/IZeroXBridgeL2.cairo
@@ -15,7 +15,7 @@ pub trait IZeroXBridgeL2<TContractState> {
         y_parity: bool,
     );
 
-    fn burn_xzb_for_unlock(ref self: TContractState, amount: core::integer::u256);
+    fn burn_xzb_for_unlock(ref self: TContractState, burn_id: u256, amount: core::integer::u256);
 }
 
 #[starknet::interface]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Burn events now include a burn_id for clearer tracking and reconciliation.
  - The burn_xzb_for_unlock call now requires a burn_id parameter alongside amount.

- Tests
  - Test suite updated to cover burn_id usage across single and multiple burn scenarios, with assertions reflecting the new event field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->