### PR TITLE
L2 contracts re-deployment

### DIFF
--- a/contracts/L2/README.md
+++ b/contracts/L2/README.md
@@ -59,8 +59,8 @@ npm run deploy:validate   # Validate deployment setup
 ### Network Configuration
 
 #### Default RPC URLs:
-- **Sepolia**: `https://starknet-sepolia.public.blastapi.io/rpc/v0_7`
-- **Mainnet**: `https://starknet-mainnet.public.blastapi.io/rpc/v0_7`
+- **Sepolia**: `https://starknet-sepolia.public.blastapi.io/rpc/v0_8`
+- **Mainnet**: `https://starknet-mainnet.public.blastapi.io/rpc/v0_8`
 - **Devnet**: `http://127.0.0.1:5050`
 
 
@@ -68,10 +68,10 @@ npm run deploy:validate   # Validate deployment setup
 
 ### Sepolia
 
-- Oracle Contract: [0x006aff010e672d581173fa959a17de9132b4e2e8ab2ce515b5d191c8f75fcc80](https://sepolia.starkscan.co/contract/0x006aff010e672d581173fa959a17de9132b4e2e8ab2ce515b5d191c8f75fcc80#read-write-contract)
+- Oracle Contract: [0x1e4acab001e40d194f15927bb0e832887a219809d0be6cf308f3e41a4cfd246](https://sepolia.starkscan.co/contract/0x1e4acab001e40d194f15927bb0e832887a219809d0be6cf308f3e41a4cfd246#read-write-contract)
 
-- Proof Registry: [0x0055c36521975f4c6a2ec2d20add8d7161022f97bc01c07cf1677005f16ea5f9](https://sepolia.starkscan.co/contract/0x0055c36521975f4c6a2ec2d20add8d7161022f97bc01c07cf1677005f16ea5f9#read-write-contract-sub-read)
+- Proof Registry: [0x3a5d9d2fce8a9dac6a6b5c8cade5668b19e30248611159c7788236a49ce8b9a](https://sepolia.starkscan.co/contract/0x3a5d9d2fce8a9dac6a6b5c8cade5668b19e30248611159c7788236a49ce8b9a#read-write-contract-sub-read)
 
-- xZBERC20: [0x00d989185d5246739f38fd5032b4ff44c2f203386b0a9b7f391c8e11967cb92b](https://sepolia.starkscan.co/contract/0x00d989185d5246739f38fd5032b4ff44c2f203386b0a9b7f391c8e11967cb92b#read-write-contract)
+- xZBERC20: [0x26cfc43ee6e47541c1de22e91382c14c2c524de52d6abdd1275e7b37cb01276](https://sepolia.starkscan.co/contract/0x26cfc43ee6e47541c1de22e91382c14c2c524de52d6abdd1275e7b37cb01276#read-write-contract)
 
-- L2Bridge: [0x0123a4ce7980e3c4f5832af0735fc3beabdc157379e09aaf7c5e62dfa8c19427](https://sepolia.starkscan.co/contract/0x0123a4ce7980e3c4f5832af0735fc3beabdc157379e09aaf7c5e62dfa8c19427#read-write-contract-sub-write)
+- L2Bridge: [0x58bdc4e4f39b648c01761324247d98ea68bc9fd5e3541e732d146385e575a63](https://sepolia.starkscan.co/contract/0x58bdc4e4f39b648c01761324247d98ea68bc9fd5e3541e732d146385e575a63#read-write-contract-sub-write)

--- a/contracts/L2/abi/L2Oracle.abi.json
+++ b/contracts/L2/abi/L2Oracle.abi.json
@@ -1,0 +1,252 @@
+[
+  {
+    "type": "impl",
+    "name": "L2Oracle",
+    "interface_name": "l2::interfaces::IL2Oracle::IL2Oracle"
+  },
+  {
+    "type": "struct",
+    "name": "core::integer::u256",
+    "members": [
+      {
+        "name": "low",
+        "type": "core::integer::u128"
+      },
+      {
+        "name": "high",
+        "type": "core::integer::u128"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "core::bool",
+    "variants": [
+      {
+        "name": "False",
+        "type": "()"
+      },
+      {
+        "name": "True",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "l2::interfaces::IL2Oracle::IL2Oracle",
+    "items": [
+      {
+        "type": "function",
+        "name": "get_total_tvl",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u256"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "set_total_tvl",
+        "inputs": [
+          {
+            "name": "tvl",
+            "type": "core::integer::u256"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "set_relayer",
+        "inputs": [
+          {
+            "name": "relayer",
+            "type": "core::starknet::contract_address::ContractAddress"
+          },
+          {
+            "name": "status",
+            "type": "core::bool"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "OwnableMixinImpl",
+    "interface_name": "openzeppelin_access::ownable::interface::OwnableABI"
+  },
+  {
+    "type": "interface",
+    "name": "openzeppelin_access::ownable::interface::OwnableABI",
+    "items": [
+      {
+        "type": "function",
+        "name": "owner",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "transfer_ownership",
+        "inputs": [
+          {
+            "name": "new_owner",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "renounce_ownership",
+        "inputs": [],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "transferOwnership",
+        "inputs": [
+          {
+            "name": "newOwner",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "renounceOwnership",
+        "inputs": [],
+        "outputs": [],
+        "state_mutability": "external"
+      }
+    ]
+  },
+  {
+    "type": "constructor",
+    "name": "constructor",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "core::starknet::contract_address::ContractAddress"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "l2::core::L2Oracle::L2Oracle::TotalTVLUpdated",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "new_tvl",
+        "type": "core::integer::u256",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "l2::core::L2Oracle::L2Oracle::RelayerStatusUpdated",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "relayer",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "data"
+      },
+      {
+        "name": "status",
+        "type": "core::bool",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferred",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "previous_owner",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      },
+      {
+        "name": "new_owner",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferStarted",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "previous_owner",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      },
+      {
+        "name": "new_owner",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_access::ownable::ownable::OwnableComponent::Event",
+    "kind": "enum",
+    "variants": [
+      {
+        "name": "OwnershipTransferred",
+        "type": "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferred",
+        "kind": "nested"
+      },
+      {
+        "name": "OwnershipTransferStarted",
+        "type": "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferStarted",
+        "kind": "nested"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "l2::core::L2Oracle::L2Oracle::Event",
+    "kind": "enum",
+    "variants": [
+      {
+        "name": "TotalTVLUpdated",
+        "type": "l2::core::L2Oracle::L2Oracle::TotalTVLUpdated",
+        "kind": "nested"
+      },
+      {
+        "name": "RelayerStatusUpdated",
+        "type": "l2::core::L2Oracle::L2Oracle::RelayerStatusUpdated",
+        "kind": "nested"
+      },
+      {
+        "name": "OwnableEvent",
+        "type": "openzeppelin_access::ownable::ownable::OwnableComponent::Event",
+        "kind": "flat"
+      }
+    ]
+  }
+]

--- a/contracts/L2/abi/ProofRegistry.abi.json
+++ b/contracts/L2/abi/ProofRegistry.abi.json
@@ -1,0 +1,108 @@
+[
+  {
+    "type": "impl",
+    "name": "ProofRegistryImpl",
+    "interface_name": "l2::interfaces::IProofRegistry::IProofRegistry"
+  },
+  {
+    "type": "enum",
+    "name": "core::bool",
+    "variants": [
+      {
+        "name": "False",
+        "type": "()"
+      },
+      {
+        "name": "True",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "l2::interfaces::IProofRegistry::IProofRegistry",
+    "items": [
+      {
+        "type": "function",
+        "name": "get_verified_merkle_root",
+        "inputs": [
+          {
+            "name": "commitment_hash",
+            "type": "core::felt252"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "check_proof",
+        "inputs": [
+          {
+            "name": "commitment_hash",
+            "type": "core::felt252"
+          },
+          {
+            "name": "merkle_root",
+            "type": "core::felt252"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::bool"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "register_deposit_proof",
+        "inputs": [
+          {
+            "name": "commitment_hash",
+            "type": "core::felt252"
+          },
+          {
+            "name": "merkle_root",
+            "type": "core::felt252"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "l2::core::ProofRegistry::ProofRegistry::DepositCommitmentHashProven",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "commitment_hash",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "merkle_root",
+        "type": "core::felt252",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "l2::core::ProofRegistry::ProofRegistry::Event",
+    "kind": "enum",
+    "variants": [
+      {
+        "name": "DepositCommitmentHashProven",
+        "type": "l2::core::ProofRegistry::ProofRegistry::DepositCommitmentHashProven",
+        "kind": "nested"
+      }
+    ]
+  }
+]

--- a/contracts/L2/abi/ZeroXBridgeL2.abi.json
+++ b/contracts/L2/abi/ZeroXBridgeL2.abi.json
@@ -1,0 +1,679 @@
+[
+  {
+    "type": "impl",
+    "name": "MintBurnXzbImpl",
+    "interface_name": "l2::interfaces::IZeroXBridgeL2::IZeroXBridgeL2"
+  },
+  {
+    "type": "struct",
+    "name": "core::integer::u256",
+    "members": [
+      {
+        "name": "low",
+        "type": "core::integer::u128"
+      },
+      {
+        "name": "high",
+        "type": "core::integer::u128"
+      }
+    ]
+  },
+  {
+    "type": "enum",
+    "name": "core::bool",
+    "variants": [
+      {
+        "name": "False",
+        "type": "()"
+      },
+      {
+        "name": "True",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "l2::interfaces::IZeroXBridgeL2::IZeroXBridgeL2",
+    "items": [
+      {
+        "type": "function",
+        "name": "mint_and_claim_xzb",
+        "inputs": [
+          {
+            "name": "proof",
+            "type": "core::array::Array::<core::felt252>"
+          },
+          {
+            "name": "commitment_hash",
+            "type": "core::felt252"
+          },
+          {
+            "name": "eth_address",
+            "type": "core::felt252"
+          },
+          {
+            "name": "r",
+            "type": "core::integer::u256"
+          },
+          {
+            "name": "s",
+            "type": "core::integer::u256"
+          },
+          {
+            "name": "y_parity",
+            "type": "core::bool"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "burn_xzb_for_unlock",
+        "inputs": [
+          {
+            "name": "burn_id",
+            "type": "core::integer::u256"
+          },
+          {
+            "name": "amount",
+            "type": "core::integer::u256"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "DynamicRateImpl",
+    "interface_name": "l2::interfaces::IZeroXBridgeL2::IDynamicRate"
+  },
+  {
+    "type": "enum",
+    "name": "core::option::Option::<core::integer::u256>",
+    "variants": [
+      {
+        "name": "Some",
+        "type": "core::integer::u256"
+      },
+      {
+        "name": "None",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "l2::interfaces::IZeroXBridgeL2::IDynamicRate",
+    "items": [
+      {
+        "type": "function",
+        "name": "get_dynamic_rate",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u256"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "get_current_xzb_supply",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u256"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "set_rates",
+        "inputs": [
+          {
+            "name": "min_rate",
+            "type": "core::option::Option::<core::integer::u256>"
+          },
+          {
+            "name": "max_rate",
+            "type": "core::option::Option::<core::integer::u256>"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "set_oracle",
+        "inputs": [
+          {
+            "name": "oracle",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "set_xzb_token",
+        "inputs": [
+          {
+            "name": "xzb_token",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "UpgradeableImpl",
+    "interface_name": "openzeppelin_upgrades::interface::IUpgradeable"
+  },
+  {
+    "type": "interface",
+    "name": "openzeppelin_upgrades::interface::IUpgradeable",
+    "items": [
+      {
+        "type": "function",
+        "name": "upgrade",
+        "inputs": [
+          {
+            "name": "new_class_hash",
+            "type": "core::starknet::class_hash::ClassHash"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "MerkleImpl",
+    "interface_name": "l2::interfaces::IMerkleManager::IMerkleManager"
+  },
+  {
+    "type": "enum",
+    "name": "core::result::Result::<core::bool, core::felt252>",
+    "variants": [
+      {
+        "name": "Ok",
+        "type": "core::bool"
+      },
+      {
+        "name": "Err",
+        "type": "core::felt252"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "l2::interfaces::IMerkleManager::IMerkleManager",
+    "items": [
+      {
+        "type": "function",
+        "name": "get_root_hash",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "get_element_count",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "get_commitment_index",
+        "inputs": [
+          {
+            "name": "commitment_hash",
+            "type": "core::felt252"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "get_last_peaks",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::array::Array::<core::felt252>"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "get_leaves_count",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "verify_proof",
+        "inputs": [
+          {
+            "name": "index",
+            "type": "core::integer::u32"
+          },
+          {
+            "name": "commitment_hash",
+            "type": "core::felt252"
+          },
+          {
+            "name": "peaks",
+            "type": "core::array::Array::<core::felt252>"
+          },
+          {
+            "name": "proof",
+            "type": "core::array::Array::<core::felt252>"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::result::Result::<core::bool, core::felt252>"
+          }
+        ],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "OwnableMixinImpl",
+    "interface_name": "openzeppelin_access::ownable::interface::OwnableABI"
+  },
+  {
+    "type": "interface",
+    "name": "openzeppelin_access::ownable::interface::OwnableABI",
+    "items": [
+      {
+        "type": "function",
+        "name": "owner",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "transfer_ownership",
+        "inputs": [
+          {
+            "name": "new_owner",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "renounce_ownership",
+        "inputs": [],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "transferOwnership",
+        "inputs": [
+          {
+            "name": "newOwner",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "renounceOwnership",
+        "inputs": [],
+        "outputs": [],
+        "state_mutability": "external"
+      }
+    ]
+  },
+  {
+    "type": "constructor",
+    "name": "constructor",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "core::starknet::contract_address::ContractAddress"
+      },
+      {
+        "name": "token",
+        "type": "core::starknet::contract_address::ContractAddress"
+      },
+      {
+        "name": "proof_registry_address",
+        "type": "core::starknet::contract_address::ContractAddress"
+      },
+      {
+        "name": "oracle_address",
+        "type": "core::starknet::contract_address::ContractAddress"
+      },
+      {
+        "name": "min_rate",
+        "type": "core::integer::u256"
+      },
+      {
+        "name": "max_rate",
+        "type": "core::integer::u256"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::BurnEvent",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "burn_id",
+        "type": "core::integer::u256",
+        "kind": "data"
+      },
+      {
+        "name": "user",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "data"
+      },
+      {
+        "name": "amount",
+        "type": "core::integer::u256",
+        "kind": "data"
+      },
+      {
+        "name": "nonce",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "commitment_hash",
+        "type": "core::felt252",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::MintEvent",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "recipient",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "data"
+      },
+      {
+        "name": "amount",
+        "type": "core::integer::u256",
+        "kind": "data"
+      },
+      {
+        "name": "nonce",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "commitment_hash",
+        "type": "core::felt252",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::RateUpdated",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "new_rate",
+        "type": "core::integer::u256",
+        "kind": "key"
+      },
+      {
+        "name": "tvl",
+        "type": "core::integer::u256",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::OracleUpdated",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "oracle",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::XZBTokenUpdated",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "xzb_token",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::RateLimitsUpdated",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "min_rate",
+        "type": "core::integer::u256",
+        "kind": "data"
+      },
+      {
+        "name": "max_rate",
+        "type": "core::integer::u256",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::WithdrawalHashAppended",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "index",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "commitment_hash",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "root_hash",
+        "type": "core::felt252",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferred",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "previous_owner",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      },
+      {
+        "name": "new_owner",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferStarted",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "previous_owner",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      },
+      {
+        "name": "new_owner",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_access::ownable::ownable::OwnableComponent::Event",
+    "kind": "enum",
+    "variants": [
+      {
+        "name": "OwnershipTransferred",
+        "type": "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferred",
+        "kind": "nested"
+      },
+      {
+        "name": "OwnershipTransferStarted",
+        "type": "openzeppelin_access::ownable::ownable::OwnableComponent::OwnershipTransferStarted",
+        "kind": "nested"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_introspection::src5::SRC5Component::Event",
+    "kind": "enum",
+    "variants": []
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Upgraded",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "class_hash",
+        "type": "core::starknet::class_hash::ClassHash",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Event",
+    "kind": "enum",
+    "variants": [
+      {
+        "name": "Upgraded",
+        "type": "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Upgraded",
+        "kind": "nested"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::Event",
+    "kind": "enum",
+    "variants": [
+      {
+        "name": "BurnEvent",
+        "type": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::BurnEvent",
+        "kind": "nested"
+      },
+      {
+        "name": "MintEvent",
+        "type": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::MintEvent",
+        "kind": "nested"
+      },
+      {
+        "name": "RateUpdated",
+        "type": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::RateUpdated",
+        "kind": "nested"
+      },
+      {
+        "name": "OracleUpdated",
+        "type": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::OracleUpdated",
+        "kind": "nested"
+      },
+      {
+        "name": "XZBTokenUpdated",
+        "type": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::XZBTokenUpdated",
+        "kind": "nested"
+      },
+      {
+        "name": "RateLimitsUpdated",
+        "type": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::RateLimitsUpdated",
+        "kind": "nested"
+      },
+      {
+        "name": "WithdrawalHashAppended",
+        "type": "l2::core::ZeroXBridgeL2::ZeroXBridgeL2::WithdrawalHashAppended",
+        "kind": "nested"
+      },
+      {
+        "name": "OwnableEvent",
+        "type": "openzeppelin_access::ownable::ownable::OwnableComponent::Event",
+        "kind": "flat"
+      },
+      {
+        "name": "SRC5Event",
+        "type": "openzeppelin_introspection::src5::SRC5Component::Event",
+        "kind": "flat"
+      },
+      {
+        "name": "UpgradeableEvent",
+        "type": "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Event",
+        "kind": "flat"
+      }
+    ]
+  }
+]

--- a/contracts/L2/abi/xZBERC20.abi.json
+++ b/contracts/L2/abi/xZBERC20.abi.json
@@ -1,0 +1,766 @@
+[
+  {
+    "type": "impl",
+    "name": "XZBERC20Impl",
+    "interface_name": "l2::interfaces::IxZBErc20::IXZBERC20"
+  },
+  {
+    "type": "struct",
+    "name": "core::integer::u256",
+    "members": [
+      {
+        "name": "low",
+        "type": "core::integer::u128"
+      },
+      {
+        "name": "high",
+        "type": "core::integer::u128"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "l2::interfaces::IxZBErc20::IXZBERC20",
+    "items": [
+      {
+        "type": "function",
+        "name": "mint",
+        "inputs": [
+          {
+            "name": "recipient",
+            "type": "core::starknet::contract_address::ContractAddress"
+          },
+          {
+            "name": "amount",
+            "type": "core::integer::u256"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "burn",
+        "inputs": [
+          {
+            "name": "amount",
+            "type": "core::integer::u256"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "set_bridge_address",
+        "inputs": [
+          {
+            "name": "bridge",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "get_bridge_address",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "function",
+    "name": "test_mint",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "core::starknet::contract_address::ContractAddress"
+      },
+      {
+        "name": "amount",
+        "type": "core::integer::u256"
+      }
+    ],
+    "outputs": [],
+    "state_mutability": "external"
+  },
+  {
+    "type": "impl",
+    "name": "UpgradeableImpl",
+    "interface_name": "openzeppelin_upgrades::interface::IUpgradeable"
+  },
+  {
+    "type": "interface",
+    "name": "openzeppelin_upgrades::interface::IUpgradeable",
+    "items": [
+      {
+        "type": "function",
+        "name": "upgrade",
+        "inputs": [
+          {
+            "name": "new_class_hash",
+            "type": "core::starknet::class_hash::ClassHash"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "ERC20MixinImpl",
+    "interface_name": "openzeppelin_token::erc20::interface::IERC20Mixin"
+  },
+  {
+    "type": "enum",
+    "name": "core::bool",
+    "variants": [
+      {
+        "name": "False",
+        "type": "()"
+      },
+      {
+        "name": "True",
+        "type": "()"
+      }
+    ]
+  },
+  {
+    "type": "struct",
+    "name": "core::byte_array::ByteArray",
+    "members": [
+      {
+        "name": "data",
+        "type": "core::array::Array::<core::bytes_31::bytes31>"
+      },
+      {
+        "name": "pending_word",
+        "type": "core::felt252"
+      },
+      {
+        "name": "pending_word_len",
+        "type": "core::integer::u32"
+      }
+    ]
+  },
+  {
+    "type": "interface",
+    "name": "openzeppelin_token::erc20::interface::IERC20Mixin",
+    "items": [
+      {
+        "type": "function",
+        "name": "total_supply",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u256"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "balance_of",
+        "inputs": [
+          {
+            "name": "account",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::integer::u256"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "allowance",
+        "inputs": [
+          {
+            "name": "owner",
+            "type": "core::starknet::contract_address::ContractAddress"
+          },
+          {
+            "name": "spender",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::integer::u256"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "transfer",
+        "inputs": [
+          {
+            "name": "recipient",
+            "type": "core::starknet::contract_address::ContractAddress"
+          },
+          {
+            "name": "amount",
+            "type": "core::integer::u256"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::bool"
+          }
+        ],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "transfer_from",
+        "inputs": [
+          {
+            "name": "sender",
+            "type": "core::starknet::contract_address::ContractAddress"
+          },
+          {
+            "name": "recipient",
+            "type": "core::starknet::contract_address::ContractAddress"
+          },
+          {
+            "name": "amount",
+            "type": "core::integer::u256"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::bool"
+          }
+        ],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "approve",
+        "inputs": [
+          {
+            "name": "spender",
+            "type": "core::starknet::contract_address::ContractAddress"
+          },
+          {
+            "name": "amount",
+            "type": "core::integer::u256"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::bool"
+          }
+        ],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "name",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "symbol",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::byte_array::ByteArray"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "decimals",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u8"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "totalSupply",
+        "inputs": [],
+        "outputs": [
+          {
+            "type": "core::integer::u256"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "balanceOf",
+        "inputs": [
+          {
+            "name": "account",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::integer::u256"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "transferFrom",
+        "inputs": [
+          {
+            "name": "sender",
+            "type": "core::starknet::contract_address::ContractAddress"
+          },
+          {
+            "name": "recipient",
+            "type": "core::starknet::contract_address::ContractAddress"
+          },
+          {
+            "name": "amount",
+            "type": "core::integer::u256"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::bool"
+          }
+        ],
+        "state_mutability": "external"
+      }
+    ]
+  },
+  {
+    "type": "impl",
+    "name": "AccessControlMixinImpl",
+    "interface_name": "openzeppelin_access::accesscontrol::interface::AccessControlABI"
+  },
+  {
+    "type": "interface",
+    "name": "openzeppelin_access::accesscontrol::interface::AccessControlABI",
+    "items": [
+      {
+        "type": "function",
+        "name": "has_role",
+        "inputs": [
+          {
+            "name": "role",
+            "type": "core::felt252"
+          },
+          {
+            "name": "account",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::bool"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "get_role_admin",
+        "inputs": [
+          {
+            "name": "role",
+            "type": "core::felt252"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "grant_role",
+        "inputs": [
+          {
+            "name": "role",
+            "type": "core::felt252"
+          },
+          {
+            "name": "account",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "revoke_role",
+        "inputs": [
+          {
+            "name": "role",
+            "type": "core::felt252"
+          },
+          {
+            "name": "account",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "renounce_role",
+        "inputs": [
+          {
+            "name": "role",
+            "type": "core::felt252"
+          },
+          {
+            "name": "account",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "hasRole",
+        "inputs": [
+          {
+            "name": "role",
+            "type": "core::felt252"
+          },
+          {
+            "name": "account",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::bool"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "getRoleAdmin",
+        "inputs": [
+          {
+            "name": "role",
+            "type": "core::felt252"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::felt252"
+          }
+        ],
+        "state_mutability": "view"
+      },
+      {
+        "type": "function",
+        "name": "grantRole",
+        "inputs": [
+          {
+            "name": "role",
+            "type": "core::felt252"
+          },
+          {
+            "name": "account",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "revokeRole",
+        "inputs": [
+          {
+            "name": "role",
+            "type": "core::felt252"
+          },
+          {
+            "name": "account",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "renounceRole",
+        "inputs": [
+          {
+            "name": "role",
+            "type": "core::felt252"
+          },
+          {
+            "name": "account",
+            "type": "core::starknet::contract_address::ContractAddress"
+          }
+        ],
+        "outputs": [],
+        "state_mutability": "external"
+      },
+      {
+        "type": "function",
+        "name": "supports_interface",
+        "inputs": [
+          {
+            "name": "interface_id",
+            "type": "core::felt252"
+          }
+        ],
+        "outputs": [
+          {
+            "type": "core::bool"
+          }
+        ],
+        "state_mutability": "view"
+      }
+    ]
+  },
+  {
+    "type": "constructor",
+    "name": "constructor",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "core::starknet::contract_address::ContractAddress"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_token::erc20::erc20::ERC20Component::Transfer",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "from",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      },
+      {
+        "name": "to",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      },
+      {
+        "name": "value",
+        "type": "core::integer::u256",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_token::erc20::erc20::ERC20Component::Approval",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "owner",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      },
+      {
+        "name": "spender",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "key"
+      },
+      {
+        "name": "value",
+        "type": "core::integer::u256",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_token::erc20::erc20::ERC20Component::Event",
+    "kind": "enum",
+    "variants": [
+      {
+        "name": "Transfer",
+        "type": "openzeppelin_token::erc20::erc20::ERC20Component::Transfer",
+        "kind": "nested"
+      },
+      {
+        "name": "Approval",
+        "type": "openzeppelin_token::erc20::erc20::ERC20Component::Approval",
+        "kind": "nested"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleGranted",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "role",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "account",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "data"
+      },
+      {
+        "name": "sender",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleRevoked",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "role",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "account",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "data"
+      },
+      {
+        "name": "sender",
+        "type": "core::starknet::contract_address::ContractAddress",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleAdminChanged",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "role",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "previous_admin_role",
+        "type": "core::felt252",
+        "kind": "data"
+      },
+      {
+        "name": "new_admin_role",
+        "type": "core::felt252",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::Event",
+    "kind": "enum",
+    "variants": [
+      {
+        "name": "RoleGranted",
+        "type": "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleGranted",
+        "kind": "nested"
+      },
+      {
+        "name": "RoleRevoked",
+        "type": "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleRevoked",
+        "kind": "nested"
+      },
+      {
+        "name": "RoleAdminChanged",
+        "type": "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::RoleAdminChanged",
+        "kind": "nested"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_introspection::src5::SRC5Component::Event",
+    "kind": "enum",
+    "variants": []
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Upgraded",
+    "kind": "struct",
+    "members": [
+      {
+        "name": "class_hash",
+        "type": "core::starknet::class_hash::ClassHash",
+        "kind": "data"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Event",
+    "kind": "enum",
+    "variants": [
+      {
+        "name": "Upgraded",
+        "type": "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Upgraded",
+        "kind": "nested"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "l2::core::xZBERC20::xZBERC20::Event",
+    "kind": "enum",
+    "variants": [
+      {
+        "name": "ERC20Event",
+        "type": "openzeppelin_token::erc20::erc20::ERC20Component::Event",
+        "kind": "flat"
+      },
+      {
+        "name": "AccessControlEvent",
+        "type": "openzeppelin_access::accesscontrol::accesscontrol::AccessControlComponent::Event",
+        "kind": "flat"
+      },
+      {
+        "name": "SRC5Event",
+        "type": "openzeppelin_introspection::src5::SRC5Component::Event",
+        "kind": "flat"
+      },
+      {
+        "name": "UpgradeableEvent",
+        "type": "openzeppelin_upgrades::upgradeable::UpgradeableComponent::Event",
+        "kind": "flat"
+      }
+    ]
+  }
+]

--- a/contracts/L2/package-lock.json
+++ b/contracts/L2/package-lock.json
@@ -13,7 +13,7 @@
         "dotenv": "^16.5.0",
         "ethers": "^6.14.3",
         "ora": "^8.2.0",
-        "starknet": "^6.24.1"
+        "starknet": "^7.6.4"
       },
       "devDependencies": {
         "@types/node": "^24.0.4",
@@ -152,6 +152,20 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@starknet-io/starknet-types-07": {
+      "name": "@starknet-io/types-js",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
+      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
+      "license": "MIT"
+    },
+    "node_modules/@starknet-io/starknet-types-08": {
+      "name": "@starknet-io/types-js",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.8.4.tgz",
+      "integrity": "sha512-0RZ3TZHcLsUTQaq1JhDSCM8chnzO4/XNsSCozwDET64JK5bjFDIf2ZUkta+tl5Nlbf4usoU7uZiDI/Q57kt2SQ==",
+      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -468,16 +482,6 @@
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "license": "MIT"
     },
-    "node_modules/fetch-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-3.0.1.tgz",
-      "integrity": "sha512-ZGXe8Y5Z/1FWqQ9q/CrJhkUD73DyBU9VF0hBQmEO/wPHe4A9PKTjplFDLeFX8aOsYypZUcX5Ji/eByn3VCVO3Q==",
-      "license": "Unlicense",
-      "dependencies": {
-        "set-cookie-parser": "^2.4.8",
-        "tough-cookie": "^4.0.0"
-      }
-    },
     "node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -552,16 +556,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -625,26 +619,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/onetime": {
@@ -741,33 +715,6 @@
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
       "license": "(MIT AND Zlib)"
     },
-    "node_modules/psl": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/lupomontero"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "license": "MIT"
-    },
     "node_modules/redeyed": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
@@ -786,12 +733,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
-    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -808,12 +749,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-      "license": "MIT"
-    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -827,30 +762,25 @@
       }
     },
     "node_modules/starknet": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/starknet/-/starknet-6.24.1.tgz",
-      "integrity": "sha512-g7tiCt73berhcNi41otlN3T3kxZnIvZhMi8WdC21Y6GC6zoQgbI2z1t7JAZF9c4xZiomlanwVnurcpyfEdyMpg==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/starknet/-/starknet-7.6.4.tgz",
+      "integrity": "sha512-FB20IaLCDbh/XomkB+19f5jmNxG+RzNdRO7QUhm7nfH81UPIt2C/MyWAlHCYkbv2wznSEb73wpxbp9tytokTgQ==",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "1.7.0",
         "@noble/hashes": "1.6.0",
         "@scure/base": "1.2.1",
         "@scure/starknet": "1.1.0",
-        "abi-wan-kanabi": "^2.2.3",
-        "fetch-cookie": "~3.0.0",
-        "isomorphic-fetch": "~3.0.0",
+        "@starknet-io/starknet-types-07": "npm:@starknet-io/types-js@~0.7.10",
+        "@starknet-io/starknet-types-08": "npm:@starknet-io/types-js@~0.8.4",
+        "abi-wan-kanabi": "2.2.4",
         "lossless-json": "^4.0.1",
         "pako": "^2.0.4",
-        "starknet-types-07": "npm:@starknet-io/types-js@^0.7.10",
         "ts-mixer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=22"
       }
-    },
-    "node_modules/starknet-types-07": {
-      "name": "@starknet-io/types-js",
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
-      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
-      "license": "MIT"
     },
     "node_modules/starknet/node_modules/@noble/curves": {
       "version": "1.7.0",
@@ -916,36 +846,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/tough-cookie": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tough-cookie/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
     },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
@@ -1033,44 +933,12 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
-      "license": "MIT"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/contracts/L2/package.json
+++ b/contracts/L2/package.json
@@ -21,7 +21,7 @@
     "dotenv": "^16.5.0",
     "ethers": "^6.14.3",
     "ora": "^8.2.0",
-    "starknet": "^6.24.1"
+    "starknet": "^7.6.4"
   },
   "devDependencies": {
     "@types/node": "^24.0.4",

--- a/contracts/L2/scripts/.deploy-config-sepolia.json
+++ b/contracts/L2/scripts/.deploy-config-sepolia.json
@@ -1,8 +1,8 @@
 {
   "network": "sepolia",
-  "accountAddress": "0x069380ac3a70c38102c8c2183a47f7741b93d61cb9dba8de595408759308b14c",
-  "starknetRpcUrl": "https://starknet-sepolia.public.blastapi.io/rpc/v0_7",
-  "owner": "0x069380ac3a70c38102c8c2183a47f7741b93d61cb9dba8de595408759308b14c",
+  "accountAddress": "0x076927323f53353790b2a6d2cb7be146bfd1fdafcf34ae0194ba454a99befa82",
+  "starknetRpcUrl": "https://starknet-sepolia.public.blastapi.io/rpc/v0_8",
+  "owner": "0x076927323f53353790b2a6d2cb7be146bfd1fdafcf34ae0194ba454a99befa82",
   "minRate": "1000000000000000000",
   "maxRate": "2000000000000000000"
 }

--- a/contracts/L2/scripts/deploy_l2.ts
+++ b/contracts/L2/scripts/deploy_l2.ts
@@ -11,8 +11,8 @@ import { Account, CallData, Contract, RpcProvider, json } from "starknet";
 dotenv.config();
 
 const DEFAULT_RPC_URLS = {
-    sepolia: "https://starknet-sepolia.public.blastapi.io/rpc/v0_7",
-    mainnet: "https://starknet-mainnet.public.blastapi.io/rpc/v0_7", 
+    sepolia: "https://starknet-sepolia.public.blastapi.io/rpc/v0_8",
+    mainnet: "https://starknet-mainnet.public.blastapi.io/rpc/v0_8", 
     devnet: "http://127.0.0.1:5050"
 };
 
@@ -312,7 +312,8 @@ async function declareContract(
             }
         }
         spinner.fail(`${contractName} declaration failed!`);
-        console.error(error.toString());
+        // console.error(error.toString());
+        fs.appendFileSync("error.log", error.toString() + "\n");
         throw error;
     }
 }
@@ -360,6 +361,7 @@ async function declareAndDeploy(
     network: string
 ): Promise<DeployedContract> {
     // Step 1: Declare the contract
+    console.log(`\n=== Processing ${contractName} ===`);
     const { classHash, declareTx } = await declareContract(contractName, account);
     
     // Step 2: Deploy using the class hash
@@ -671,7 +673,7 @@ async function main(): Promise<void> {
 // Execute if this file is run directly
 if (require.main === module) {
     main().then(() => process.exit(0)).catch((error) => {
-        console.error("Deployment failed:", error);
+        // console.error("Deployment failed:", error);
         process.exit(1);
     });
 }

--- a/contracts/L2/scripts/deploy_l2.ts
+++ b/contracts/L2/scripts/deploy_l2.ts
@@ -312,8 +312,7 @@ async function declareContract(
             }
         }
         spinner.fail(`${contractName} declaration failed!`);
-        // console.error(error.toString());
-        fs.appendFileSync("error.log", error.toString() + "\n");
+        console.error(error.toString());
         throw error;
     }
 }
@@ -673,7 +672,7 @@ async function main(): Promise<void> {
 // Execute if this file is run directly
 if (require.main === module) {
     main().then(() => process.exit(0)).catch((error) => {
-        // console.error("Deployment failed:", error);
+        console.error("Deployment failed:", error);
         process.exit(1);
     });
 }

--- a/contracts/L2/scripts/deploy_l2.ts
+++ b/contracts/L2/scripts/deploy_l2.ts
@@ -4,7 +4,7 @@ import path from "path";
 import dotenv from "dotenv";
 import ora from "ora";
 import { Command } from "commander";
-import { Account, CallData, Contract, RpcProvider, json, provider } from "starknet";
+import { Account, CallData, Contract, RpcProvider, json } from "starknet";
 
 // === Constants ==================================================================================
 
@@ -373,16 +373,16 @@ async function declareAndDeploy(
         network
     );
 
-    // Step 3: Get contract abi
+    // Step 3: Get contract ABI and save it under contracts/L2/abi
     const provider = new RpcProvider({ nodeUrl: config.starknetRpcUrl! });
     const { abi } = await provider.getClassAt(address);
-    if (!fs.existsSync("abi")) {
-        fs.mkdirSync("abi");
+    const outDir = path.join(__dirname, "..", "abi");
+    if (!fs.existsSync(outDir)) {
+      fs.mkdirSync(outDir, { recursive: true });
     }
-
-    // Save ABI to file
-    console.log(`Saving ABI for ${contractName} to abi/${contractName}.abi.json`);
-    fs.writeFileSync(`abi/${contractName}.abi.json`, JSON.stringify(abi, null, 2));
+    const outPath = path.join(outDir, `${contractName}.abi.json`);
+    console.log(`Saving ABI for ${contractName} to ${outPath}`);
+    fs.writeFileSync(outPath, JSON.stringify(abi, null, 2));
     
     return {
         address,

--- a/contracts/L2/scripts/deployments-sepolia.json
+++ b/contracts/L2/scripts/deployments-sepolia.json
@@ -1,34 +1,26 @@
 {
   "ProofRegistry": {
-    "address": "0x2d55767c6dadedb374237d1080f864c7883d98ed39005441bba2bf1dab30c65",
-    "classHash": "0x01bbe0bd0a7ff088497b3ae3de5d777b32df7941774eed4a433a87d30545f8d7",
-    "declareTx": "already_declared",
-    "deploymentTx": "0x236007d86c40cb02dd2640d2ac93ea34724818d9cdb6463a76e58afcdfe232",
-    "timestamp": 1751003276417,
+    "address": "0x231aab1c82042819d5af1538f0da5dbef3407561cfa8b9c230a685b9c4e8939",
+    "classHash": "0x6f77f96384e52ae128281efc54d778db59ffa84c26a4f21e737b05374ca36d8",
+    "declareTx": "0x6a5b8b90c3c61fe8ce6b9f2a640e23fa701d3895769f61a7ed2eaf5603e0bdd",
+    "deploymentTx": "0xe5783d73c84c6b74c3ed1bd187d4a7338e6a0b9a158b39154b7c19c30d324b",
+    "timestamp": 1756157239635,
     "network": "sepolia"
   },
   "L2Oracle": {
-    "address": "0x552753fccbc71a1d0e7d0295a436fed27535b178c8da4f434f8186ce7df5c39",
-    "classHash": "0x033549e7e600899a8521a0ecee3ccce0a258247436fc1e6f69388ca18ebf09f0",
-    "declareTx": "already_declared",
-    "deploymentTx": "0x60c8d188f59e8fe813c729d498425aec3bf34106868578d006de60876815b02",
-    "timestamp": 1751003301250,
+    "address": "0x1a5a982d4eac3fca0741c7ac3ee38630925805fa4c8b009eabe99a9487d890c",
+    "classHash": "0x582f0d180cafc7a395737f78c3cdc6b536c0984b883c1d1d90296a8a250d08b",
+    "declareTx": "0x278c9721ce438cfb378886cc997fd623068f706dca1e21a2e25003477d37cda",
+    "deploymentTx": "0x4f17480b42eb4d422217e63176b8a69fa461b9804088401b6e38b5afd03195",
+    "timestamp": 1756157301497,
     "network": "sepolia"
   },
   "xZBERC20": {
-    "address": "0x4a011be1a7eb09902ba495b2bfb46e82e1013a00bd8bb47a0c05856c5aab602",
-    "classHash": "0x68ca653cc333c61a7f3b88fd203d1f5cc47b2dd7996a6398b4eea8c4bd99df2",
-    "declareTx": "0x22c1f9f9514b8ee5e44d43499784dcac3ed30e4be231e9d2f76f1db931c89b6",
-    "deploymentTx": "0x67b0d1146b96c80e980e80626e7d55198ff2d8a2018c6b7e215d523780fb667",
-    "timestamp": 1751003344209,
-    "network": "sepolia"
-  },
-  "ZeroXBridgeL2": {
-    "address": "0x63ec02e40fc049b762a6a71f28fd99e744746743c44fc864a763b0398eea127",
-    "classHash": "0x0108af8d915a1576e9c5206285cce22db400f95783602705e664c4485b8237d7",
-    "declareTx": "already_declared",
-    "deploymentTx": "0x7e02cfd98ba3ba4e23630fa63ecdad331fb65d97ab4b4c3bf005e6890c5c192",
-    "timestamp": 1751005151931,
+    "address": "0xc09dbb49e272a69dd3523aaec1344b3855a90ce5736d4de248c32b67a73a9a",
+    "classHash": "0x51693e46ab578398a490146be338870e7cc919638065f80d2e39eaec3bf9c4",
+    "declareTx": "0x71b3d7d8622800b1cb150be8e8c7887ec5048fe548e5149731441d7b82ae443",
+    "deploymentTx": "0x78eb2275af5d9c83a9838ab65dc05d771ffe43249e6fe3fa3c33f09089dc3b9",
+    "timestamp": 1756157371521,
     "network": "sepolia"
   }
 }

--- a/contracts/L2/scripts/deployments-sepolia.json
+++ b/contracts/L2/scripts/deployments-sepolia.json
@@ -22,5 +22,13 @@
     "deploymentTx": "0x78eb2275af5d9c83a9838ab65dc05d771ffe43249e6fe3fa3c33f09089dc3b9",
     "timestamp": 1756157371521,
     "network": "sepolia"
+  },
+  "ZeroXBridgeL2": {
+    "address": "0x62359721fdd812aa83ced7f0b74741cfb544f77bfe54ce15ec9e9c4136015da",
+    "classHash": "0x01fcf01b6873a91e4b6942b2596d3dc3f5e5867ba0fb9b5817202c01f6703eb3",
+    "declareTx": "already_declared",
+    "deploymentTx": "0x397447f8fac654cf3b6b3728480edfca9459969e97f9a89c7fcc2f8a144b465",
+    "timestamp": 1756213282767,
+    "network": "sepolia"
   }
 }

--- a/contracts/L2/scripts/deployments-sepolia.json
+++ b/contracts/L2/scripts/deployments-sepolia.json
@@ -1,34 +1,34 @@
 {
   "ProofRegistry": {
-    "address": "0x231aab1c82042819d5af1538f0da5dbef3407561cfa8b9c230a685b9c4e8939",
-    "classHash": "0x6f77f96384e52ae128281efc54d778db59ffa84c26a4f21e737b05374ca36d8",
-    "declareTx": "0x6a5b8b90c3c61fe8ce6b9f2a640e23fa701d3895769f61a7ed2eaf5603e0bdd",
-    "deploymentTx": "0xe5783d73c84c6b74c3ed1bd187d4a7338e6a0b9a158b39154b7c19c30d324b",
-    "timestamp": 1756157239635,
+    "address": "0x3a5d9d2fce8a9dac6a6b5c8cade5668b19e30248611159c7788236a49ce8b9a",
+    "classHash": "0x06f77f96384e52ae128281efc54d778db59ffa84c26a4f21e737b05374ca36d8",
+    "declareTx": "already_declared",
+    "deploymentTx": "0x43ede94c1779eda90ae09ccb55ccc9a69236c9c7a52d6e507f01242e3238bc6",
+    "timestamp": 1756215260959,
     "network": "sepolia"
   },
   "L2Oracle": {
-    "address": "0x1a5a982d4eac3fca0741c7ac3ee38630925805fa4c8b009eabe99a9487d890c",
-    "classHash": "0x582f0d180cafc7a395737f78c3cdc6b536c0984b883c1d1d90296a8a250d08b",
-    "declareTx": "0x278c9721ce438cfb378886cc997fd623068f706dca1e21a2e25003477d37cda",
-    "deploymentTx": "0x4f17480b42eb4d422217e63176b8a69fa461b9804088401b6e38b5afd03195",
-    "timestamp": 1756157301497,
+    "address": "0x1e4acab001e40d194f15927bb0e832887a219809d0be6cf308f3e41a4cfd246",
+    "classHash": "0x0582f0d180cafc7a395737f78c3cdc6b536c0984b883c1d1d90296a8a250d08b",
+    "declareTx": "already_declared",
+    "deploymentTx": "0x47e2d88d3befe64a004a95d9307ef9fdf53fdce5bc151c1f0f3c4fdcb058ea1",
+    "timestamp": 1756215293034,
     "network": "sepolia"
   },
   "xZBERC20": {
-    "address": "0xc09dbb49e272a69dd3523aaec1344b3855a90ce5736d4de248c32b67a73a9a",
-    "classHash": "0x51693e46ab578398a490146be338870e7cc919638065f80d2e39eaec3bf9c4",
-    "declareTx": "0x71b3d7d8622800b1cb150be8e8c7887ec5048fe548e5149731441d7b82ae443",
-    "deploymentTx": "0x78eb2275af5d9c83a9838ab65dc05d771ffe43249e6fe3fa3c33f09089dc3b9",
-    "timestamp": 1756157371521,
+    "address": "0x26cfc43ee6e47541c1de22e91382c14c2c524de52d6abdd1275e7b37cb01276",
+    "classHash": "0x0051693e46ab578398a490146be338870e7cc919638065f80d2e39eaec3bf9c4",
+    "declareTx": "already_declared",
+    "deploymentTx": "0x4571beca8c7b07101c6a1fe999176b103d6a750ca5c2e6644ba10c01b1499f0",
+    "timestamp": 1756215325846,
     "network": "sepolia"
   },
   "ZeroXBridgeL2": {
-    "address": "0x62359721fdd812aa83ced7f0b74741cfb544f77bfe54ce15ec9e9c4136015da",
+    "address": "0x58bdc4e4f39b648c01761324247d98ea68bc9fd5e3541e732d146385e575a63",
     "classHash": "0x01fcf01b6873a91e4b6942b2596d3dc3f5e5867ba0fb9b5817202c01f6703eb3",
     "declareTx": "already_declared",
-    "deploymentTx": "0x397447f8fac654cf3b6b3728480edfca9459969e97f9a89c7fcc2f8a144b465",
-    "timestamp": 1756213282767,
+    "deploymentTx": "0x676893b3879f50995a7ea25c9a94de8b5d61e061531d29be82032bb58631ee6",
+    "timestamp": 1756215397149,
     "network": "sepolia"
   }
 }

--- a/contracts/L2/src/core/ZeroXBridgeL2.cairo
+++ b/contracts/L2/src/core/ZeroXBridgeL2.cairo
@@ -446,10 +446,6 @@ pub mod ZeroXBridgeL2 {
                     let correct_leaf_index = Self::leaf_count_to_mmr_index(leaves_count) + 1;
                     self.commitment_hash_to_index.write(commitment_hash, correct_leaf_index);
 
-                    println!("Leaf data");
-                    println!("{:?}", leaves_count);
-                    println!("{:?}", correct_leaf_index);
-
                     leaves_count += 1;
                     self.leaves_count.write(leaves_count);
 

--- a/contracts/L2/yarn.lock
+++ b/contracts/L2/yarn.lock
@@ -81,6 +81,16 @@
     "@noble/curves" "~1.7.0"
     "@noble/hashes" "~1.6.0"
 
+"@starknet-io/starknet-types-07@npm:@starknet-io/types-js@~0.7.10":
+  version "0.7.10"
+  resolved "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz"
+  integrity sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==
+
+"@starknet-io/starknet-types-08@npm:@starknet-io/types-js@~0.8.4":
+  version "0.8.4"
+  resolved "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.8.4.tgz"
+  integrity sha512-0RZ3TZHcLsUTQaq1JhDSCM8chnzO4/XNsSCozwDET64JK5bjFDIf2ZUkta+tl5Nlbf4usoU7uZiDI/Q57kt2SQ==
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
   resolved "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz"
@@ -115,7 +125,7 @@
   dependencies:
     undici-types "~6.19.2"
 
-abi-wan-kanabi@^2.2.3:
+abi-wan-kanabi@2.2.4:
   version "2.2.4"
   resolved "https://registry.npmjs.org/abi-wan-kanabi/-/abi-wan-kanabi-2.2.4.tgz"
   integrity sha512-0aA81FScmJCPX+8UvkXLki3X1+yPQuWxEkqXBVKltgPAK79J+NB+Lp5DouMXa7L6f+zcRlIA/6XO7BN/q9fnvg==
@@ -268,14 +278,6 @@ ethers@^6.14.3:
     tslib "2.7.0"
     ws "8.17.1"
 
-fetch-cookie@~3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-3.0.1.tgz"
-  integrity sha512-ZGXe8Y5Z/1FWqQ9q/CrJhkUD73DyBU9VF0hBQmEO/wPHe4A9PKTjplFDLeFX8aOsYypZUcX5Ji/eByn3VCVO3Q==
-  dependencies:
-    set-cookie-parser "^2.4.8"
-    tough-cookie "^4.0.0"
-
 fs-extra@^10.0.0:
   version "10.1.0"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz"
@@ -320,14 +322,6 @@ is-unicode-supported@^2.0.0:
   resolved "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz"
   integrity sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==
 
-isomorphic-fetch@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz"
-  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
-  dependencies:
-    node-fetch "^2.6.1"
-    whatwg-fetch "^3.4.1"
-
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz"
@@ -360,13 +354,6 @@ mimic-function@^5.0.0:
   resolved "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz"
   integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
 
-node-fetch@^2.6.1:
-  version "2.7.0"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz"
-  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
-  dependencies:
-    whatwg-url "^5.0.0"
-
 onetime@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz"
@@ -394,23 +381,6 @@ pako@^2.0.4:
   resolved "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz"
   integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
-psl@^1.1.33:
-  version "1.15.0"
-  resolved "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz"
-  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
-  dependencies:
-    punycode "^2.3.1"
-
-punycode@^2.1.1, punycode@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
-  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
-
-querystringify@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz"
-  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
-
 redeyed@~2.1.0:
   version "2.1.1"
   resolved "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz"
@@ -423,11 +393,6 @@ require-directory@^2.1.1:
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
-requires-port@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
-  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
-
 restore-cursor@^5.0.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz"
@@ -436,36 +401,25 @@ restore-cursor@^5.0.0:
     onetime "^7.0.0"
     signal-exit "^4.1.0"
 
-set-cookie-parser@^2.4.8:
-  version "2.7.1"
-  resolved "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz"
-  integrity sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==
-
 signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
-"starknet-types-07@npm:@starknet-io/types-js@^0.7.10":
-  version "0.7.10"
-  resolved "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz"
-  integrity sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==
-
-starknet@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.npmjs.org/starknet/-/starknet-6.24.1.tgz"
-  integrity sha512-g7tiCt73berhcNi41otlN3T3kxZnIvZhMi8WdC21Y6GC6zoQgbI2z1t7JAZF9c4xZiomlanwVnurcpyfEdyMpg==
+starknet@^7.6.4:
+  version "7.6.4"
+  resolved "https://registry.npmjs.org/starknet/-/starknet-7.6.4.tgz"
+  integrity sha512-FB20IaLCDbh/XomkB+19f5jmNxG+RzNdRO7QUhm7nfH81UPIt2C/MyWAlHCYkbv2wznSEb73wpxbp9tytokTgQ==
   dependencies:
     "@noble/curves" "1.7.0"
     "@noble/hashes" "1.6.0"
     "@scure/base" "1.2.1"
     "@scure/starknet" "1.1.0"
-    abi-wan-kanabi "^2.2.3"
-    fetch-cookie "~3.0.0"
-    isomorphic-fetch "~3.0.0"
+    "@starknet-io/starknet-types-07" "npm:@starknet-io/types-js@~0.7.10"
+    "@starknet-io/starknet-types-08" "npm:@starknet-io/types-js@~0.8.4"
+    abi-wan-kanabi "2.2.4"
     lossless-json "^4.0.1"
     pako "^2.0.4"
-    starknet-types-07 "npm:@starknet-io/types-js@^0.7.10"
     ts-mixer "^6.0.3"
 
 stdin-discarder@^0.2.2:
@@ -504,21 +458,6 @@ strip-ansi@^7.1.0:
   integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
   dependencies:
     ansi-regex "^6.0.1"
-
-tough-cookie@^4.0.0:
-  version "4.1.4"
-  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz"
-  integrity sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==
-  dependencies:
-    psl "^1.1.33"
-    punycode "^2.1.1"
-    universalify "^0.2.0"
-    url-parse "^1.5.3"
-
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 ts-mixer@^6.0.3:
   version "6.0.4"
@@ -564,46 +503,15 @@ undici-types@~7.8.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz"
   integrity sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==
 
-universalify@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz"
-  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
-
 universalify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
-url-parse@^1.5.3:
-  version "1.5.10"
-  resolved "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz"
-  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
-  dependencies:
-    querystringify "^2.1.1"
-    requires-port "^1.0.0"
-
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
-
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
-whatwg-fetch@^3.4.1:
-  version "3.6.20"
-  resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz"
-  integrity sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
This PR fixes an issue with L2 contract deployment.

## Changes
- ZeroXBridgeL2.cairo: removed unnecessary `println!` statements that caused contract declaration failures
- Updated **RPC** to v8
- Updated **starknet.js** to v7.6.4

Closes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Published updated L2 contract ABIs for oracle, bridge, token, and proof registry (new public interfaces, constructors, and events).
  - Deployment now logs per-contract processing and automatically saves fetched ABIs.

- Refactor
  - Removed debug printouts from the L2 bridge contract for cleaner runtime output.

- Documentation
  - Updated network RPC URLs and refreshed Sepolia deployed contract addresses.

- Chores
  - Bumped StarkNet dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->